### PR TITLE
Develop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	// 3. querydsl dependencies 추가
 	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
 	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+	// jwt
+	implementation "io.jsonwebtoken:jjwt:0.9.1";
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/yun/config/web/WebConfig.java
+++ b/src/main/java/com/example/yun/config/web/WebConfig.java
@@ -1,6 +1,7 @@
 package com.example.yun.config.web;
 
 import com.example.yun.interceptor.BaseInterceptor;
+import com.example.yun.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -9,10 +10,12 @@ import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
     @Value("${origin.address}")
     private String origin;
+    private final JwtProvider jwtProvider;
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -26,7 +29,7 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(new BaseInterceptor())
+        registry.addInterceptor(new BaseInterceptor(jwtProvider))
                 .order(1)
                 .addPathPatterns("/**")
                 .excludePathPatterns("/api/member/create", "/api/member/login");

--- a/src/main/java/com/example/yun/config/web/WebConfig.java
+++ b/src/main/java/com/example/yun/config/web/WebConfig.java
@@ -1,8 +1,11 @@
 package com.example.yun.config.web;
 
+import com.example.yun.interceptor.BaseInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -19,5 +22,13 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedHeaders("*")
                 .allowCredentials(true)
                 .maxAge(3000L);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new BaseInterceptor())
+                .order(1)
+                .addPathPatterns("/**")
+                .excludePathPatterns("/api/member/create", "/api/member/login");
     }
 }

--- a/src/main/java/com/example/yun/config/web/WebConfig.java
+++ b/src/main/java/com/example/yun/config/web/WebConfig.java
@@ -1,5 +1,6 @@
 package com.example.yun.config.web;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,10 +8,13 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    @Value("${origin.address}")
+    private String origin;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:8000")
+                .allowedOrigins(origin)
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true)

--- a/src/main/java/com/example/yun/controller/BoardController.java
+++ b/src/main/java/com/example/yun/controller/BoardController.java
@@ -46,7 +46,7 @@ public class BoardController {
         log.info("board request dto = {} ", boardRequestDto);
 
         BoardResponseDto boardResponseDto = boardService.boardCreate(boardRequestDto.getTitle(),
-                boardRequestDto.getContent());
+                boardRequestDto.getContent(), boardRequestDto.getEmail());
 
         return new ResponseEntity<>(boardResponseDto, CREATED);
     }

--- a/src/main/java/com/example/yun/controller/CommentController.java
+++ b/src/main/java/com/example/yun/controller/CommentController.java
@@ -1,0 +1,42 @@
+package com.example.yun.controller;
+
+import com.example.yun.dto.comment.CommentRequestDto;
+import com.example.yun.dto.comment.CommentResponseDto;
+import com.example.yun.service.CommentService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/comment")
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("")
+    public ResponseEntity<CommentResponseDto> createCommentApi(@RequestHeader("Authorizaiton") String jwt,
+                                                               @RequestBody @Valid CommentRequestDto commentRequestDto)
+                                                                throws JsonProcessingException {
+
+        CommentResponseDto commentCreate = commentService.commentCreate(commentRequestDto.getBoardId(), jwt, commentRequestDto.getContent());
+
+        return new ResponseEntity<>(commentCreate, CREATED);
+    }
+
+    @GetMapping("/{boardId}")
+    public ResponseEntity<List<CommentResponseDto>> findCommentApi(@PathVariable Long boardId) {
+        List<CommentResponseDto> commentResponseDtos = commentService.findCommentsBoardById(boardId);
+
+        return new ResponseEntity<>(commentResponseDtos, OK);
+    }
+}
+
+

--- a/src/main/java/com/example/yun/controller/MemberController.java
+++ b/src/main/java/com/example/yun/controller/MemberController.java
@@ -5,10 +5,10 @@ import com.example.yun.dto.member.MemberRequestDto;
 import com.example.yun.dto.member.MemberResponseDto;
 import com.example.yun.dto.member.login.LoginRequestDto;
 import com.example.yun.dto.member.login.LoginResponseDto;
+import com.example.yun.jwt.JwtObject;
+import com.example.yun.jwt.JwtProvider;
 import com.example.yun.service.MemberService;
-import com.example.yun.util.jwt.JwtUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +29,7 @@ import static org.springframework.http.HttpStatus.OK;
 public class MemberController {
 
     private final MemberService memberService;
-    private final ObjectMapper objectMapper;
+    private final JwtProvider jwtProvider;
 
     @PostMapping("/create")
     public ResponseEntity<MemberResponseDto> memberCreateApi(@RequestBody @Valid MemberRequestDto memberRequestDto) {
@@ -44,7 +44,7 @@ public class MemberController {
 
         log.info("[token] = {}", jwt);
 
-        Member jwtMember = tokenExtractMember(jwt);
+        JwtObject jwtMember = jwtProvider.tokenPayloadExtract(jwt);
 
         Member member = memberService.findMember(jwtMember.getId());
 
@@ -57,14 +57,5 @@ public class MemberController {
         String token = memberService.login(loginRequestDto.getEmail(), loginRequestDto.getPassword());
 
         return new ResponseEntity<>(LoginResponseDto.create(token), OK);
-    }
-
-    private Member tokenExtractMember(String token) throws JsonProcessingException {
-
-        String extract = JwtUtil.tokenPayloadExtract(token);
-
-        log.info("[extract] = {}", extract);
-
-        return objectMapper.readValue(extract, Member.class);
     }
 }

--- a/src/main/java/com/example/yun/controller/MemberController.java
+++ b/src/main/java/com/example/yun/controller/MemberController.java
@@ -5,8 +5,6 @@ import com.example.yun.dto.member.MemberRequestDto;
 import com.example.yun.dto.member.MemberResponseDto;
 import com.example.yun.dto.member.login.LoginRequestDto;
 import com.example.yun.dto.member.login.LoginResponseDto;
-import com.example.yun.jwt.JwtObject;
-import com.example.yun.jwt.JwtProvider;
 import com.example.yun.service.MemberService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +27,6 @@ import static org.springframework.http.HttpStatus.OK;
 public class MemberController {
 
     private final MemberService memberService;
-    private final JwtProvider jwtProvider;
 
     @PostMapping("/create")
     public ResponseEntity<MemberResponseDto> memberCreateApi(@RequestBody @Valid MemberRequestDto memberRequestDto) {
@@ -42,11 +39,7 @@ public class MemberController {
     @GetMapping("")
     public ResponseEntity<MemberResponseDto> findMemberApi(@RequestHeader("Authorization") String jwt) throws JsonProcessingException {
 
-        log.info("[token] = {}", jwt);
-
-        JwtObject jwtMember = jwtProvider.tokenPayloadExtract(jwt);
-
-        Member member = memberService.findMember(jwtMember.getId());
+        Member member = memberService.findMember(jwt);
 
         return new ResponseEntity<>(create(member), OK);
     }

--- a/src/main/java/com/example/yun/controller/MemberController.java
+++ b/src/main/java/com/example/yun/controller/MemberController.java
@@ -1,0 +1,70 @@
+package com.example.yun.controller;
+
+import com.example.yun.domain.member.Member;
+import com.example.yun.dto.member.MemberRequestDto;
+import com.example.yun.dto.member.MemberResponseDto;
+import com.example.yun.dto.member.login.LoginRequestDto;
+import com.example.yun.dto.member.login.LoginResponseDto;
+import com.example.yun.service.MemberService;
+import com.example.yun.util.jwt.JwtUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+import static com.example.yun.dto.member.MemberResponseDto.create;
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.OK;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+@RequestMapping("/api/member")
+@Validated
+public class MemberController {
+
+    private final MemberService memberService;
+    private final ObjectMapper objectMapper;
+
+    @PostMapping("/create")
+    public ResponseEntity<MemberResponseDto> memberCreateApi(@RequestBody @Valid MemberRequestDto memberRequestDto) {
+        Member memberCreate = memberService
+                .memberCreate(memberRequestDto.getEmail(), memberRequestDto.getPassword());
+
+        return new ResponseEntity<>(create(memberCreate), CREATED);
+    }
+
+    @GetMapping("")
+    public ResponseEntity<MemberResponseDto> findMemberApi(@RequestHeader("Authorization") String jwt) throws JsonProcessingException {
+
+        log.info("[token] = {}", jwt);
+
+        Member jwtMember = tokenExtractMember(jwt);
+
+        Member member = memberService.findMember(jwtMember.getId());
+
+        return new ResponseEntity<>(create(member), OK);
+    }
+
+    @GetMapping("/login")
+    public ResponseEntity<LoginResponseDto> login(@RequestBody @Valid LoginRequestDto loginRequestDto) throws JsonProcessingException {
+
+        String token = memberService.login(loginRequestDto.getEmail(), loginRequestDto.getPassword());
+
+        return new ResponseEntity<>(LoginResponseDto.create(token), OK);
+    }
+
+    private Member tokenExtractMember(String token) throws JsonProcessingException {
+
+        String extract = JwtUtil.tokenPayloadExtract(token);
+
+        log.info("[extract] = {}", extract);
+
+        return objectMapper.readValue(extract, Member.class);
+    }
+}

--- a/src/main/java/com/example/yun/controller/exception/BoardException.java
+++ b/src/main/java/com/example/yun/controller/exception/BoardException.java
@@ -1,9 +1,9 @@
 package com.example.yun.controller.exception;
 
 import com.example.yun.error.ErrorResult;
+import com.example.yun.exception.StringValidationException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -29,12 +29,32 @@ public class BoardException {
 
     @ExceptionHandler
     @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @Operation(summary = "예외", description = "제목과 내용이 주어진 형식에 맞지 않는 경우")
+    @ApiResponse(responseCode = "400", description = "BAD_REQUEST")
+    public ResponseEntity<ErrorResult> titleOrContentValidatedException(StringValidationException exception) {
+        log.info("[exception]", exception);
+
+        return getErrorResultResponseEntity(HttpStatus.BAD_REQUEST, exception);
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @Operation(summary = "예외", description = "Request Param 유효성")
     @ApiResponse(responseCode = "400", description = "BAD_REQUEST")
     public ResponseEntity<ErrorResult> badRequestException(ConstraintViolationException exception) {
         log.info("[exception]", exception);
 
         return getErrorResultResponseEntity(HttpStatus.BAD_REQUEST, exception);
+    }
+
+    @ExceptionHandler
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @Operation(summary = "예외", description = "RuntimeException 처리")
+    @ApiResponse(responseCode = "500", description = "INTERNAL_SERVER_ERROR")
+    public ResponseEntity<ErrorResult> runTimeException(RuntimeException exception) {
+        log.info("[exception]", exception);
+
+        return getErrorResultResponseEntity(HttpStatus.INTERNAL_SERVER_ERROR, exception);
     }
 
     private static ResponseEntity<ErrorResult> getErrorResultResponseEntity(HttpStatus status, Exception exception) {

--- a/src/main/java/com/example/yun/domain/Comment/Comment.java
+++ b/src/main/java/com/example/yun/domain/Comment/Comment.java
@@ -1,0 +1,38 @@
+package com.example.yun.domain.Comment;
+
+import com.example.yun.domain.BaseEntity;
+import com.example.yun.domain.board.Board;
+import com.example.yun.domain.member.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id @GeneratedValue
+    private Long id;
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+    private Comment(final String content, final Member member, final Board board) {
+        this.content = content;
+        this.member = member;
+        this.board = board;
+    }
+
+    public static Comment commentCreate(final String content, final Member member, final Board board) {
+        return new Comment(content, member, board);
+    }
+}

--- a/src/main/java/com/example/yun/domain/Comment/Comment.java
+++ b/src/main/java/com/example/yun/domain/Comment/Comment.java
@@ -3,11 +3,15 @@ package com.example.yun.domain.Comment;
 import com.example.yun.domain.BaseEntity;
 import com.example.yun.domain.board.Board;
 import com.example.yun.domain.member.Member;
+import com.example.yun.util.board.BoardValidationUtil;
+import com.example.yun.util.member.MemberValidationUtil;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+
+import static com.example.yun.util.member.MemberValidationUtil.*;
 
 @Entity
 @Getter
@@ -33,6 +37,9 @@ public class Comment extends BaseEntity {
     }
 
     public static Comment commentCreate(final String content, final Member member, final Board board) {
+
+        emailValidationCheck(member.getEmail());
+
         return new Comment(content, member, board);
     }
 }

--- a/src/main/java/com/example/yun/domain/board/Board.java
+++ b/src/main/java/com/example/yun/domain/board/Board.java
@@ -19,9 +19,13 @@ public class Board extends BaseEntity {
     private Title title;
     private Content content;
 
-    public Board(final Title title, final Content content) {
-        this.title = title;
-        this.content = content;
+    public Board(final String title, final String content) {
+        this.title = Title.titleCreate(title);
+        this.content = Content.contentCreate(content);
+    }
+
+    public static Board create(final String title, final String content) {
+        return new Board(title, content);
     }
 
     public String getTitle() {

--- a/src/main/java/com/example/yun/domain/board/Board.java
+++ b/src/main/java/com/example/yun/domain/board/Board.java
@@ -1,13 +1,12 @@
 package com.example.yun.domain.board;
 
 import com.example.yun.domain.BaseEntity;
+import com.example.yun.domain.member.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -19,13 +18,18 @@ public class Board extends BaseEntity {
     private Title title;
     private Content content;
 
-    public Board(final String title, final String content) {
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private Board(final String title, final String content, final Member member) {
         this.title = Title.titleCreate(title);
         this.content = Content.contentCreate(content);
+        this.member = member;
     }
 
-    public static Board create(final String title, final String content) {
-        return new Board(title, content);
+    public static Board create(final String title, final String content, final Member member) {
+        return new Board(title, content, member);
     }
 
     public String getTitle() {

--- a/src/main/java/com/example/yun/domain/board/Board.java
+++ b/src/main/java/com/example/yun/domain/board/Board.java
@@ -5,8 +5,9 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
-import java.util.Stack;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -15,27 +16,24 @@ public class Board extends BaseEntity {
 
     @Id @GeneratedValue
     private Long id;
+    private Title title;
+    private Content content;
 
-    @Column(name = "title")
-    private String title;
-
-    @Lob
-    @Column(name = "content")
-    private String content;
-
-    public Board(String title, String content) {
+    public Board(final Title title, final Content content) {
         this.title = title;
         this.content = content;
     }
 
-    // 테스트 목적 setId
-    public void setId(Long id) {
-        this.id = id;
+    public String getTitle() {
+        return title.getTitle();
     }
-    public void updateTitle(String title) {
+    public String getContent() {
+        return content.getContent();
+    }
+    public void updateTitle(Title title) {
         this.title = title;
     }
-    public void updateContent(String content) {
+    public void updateContent(Content content) {
         this.content = content;
     }
 }

--- a/src/main/java/com/example/yun/domain/board/Content.java
+++ b/src/main/java/com/example/yun/domain/board/Content.java
@@ -1,0 +1,33 @@
+package com.example.yun.domain.board;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+import static com.example.yun.util.DomainStringValidationUtil.contentStringNullException;
+import static com.example.yun.util.DomainStringValidationUtil.stringSettingTrim;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Content {
+
+    private String content;
+
+    private Content(String content) {
+        this.content = content;
+    }
+
+    // 정적 팩토리 메서드는 네이밍 컨벤션이 있지만 알기 쉽게 네이밍을 했다.
+    public static Content contentCreate(String content) {
+        String str = "";
+
+        if(contentStringNullException(content)) {
+            str = stringSettingTrim(content);
+        }
+
+        return new Content(str);
+    }
+}

--- a/src/main/java/com/example/yun/domain/board/Content.java
+++ b/src/main/java/com/example/yun/domain/board/Content.java
@@ -6,8 +6,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
 
-import static com.example.yun.util.DomainStringValidationUtil.contentStringNullException;
-import static com.example.yun.util.DomainStringValidationUtil.stringSettingTrim;
+import static com.example.yun.util.board.BoardValidationUtil.contentStringNullException;
+import static com.example.yun.util.board.BoardValidationUtil.stringSettingTrim;
 
 @Embeddable
 @Getter

--- a/src/main/java/com/example/yun/domain/board/Title.java
+++ b/src/main/java/com/example/yun/domain/board/Title.java
@@ -1,0 +1,30 @@
+package com.example.yun.domain.board;
+
+import com.example.yun.util.DomainStringValidationUtil;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Title {
+
+    private String title;
+
+    private Title(String title) {
+        this.title = title;
+    }
+
+    public static Title titleCreate(String title) {
+        String str = "";
+
+        if(DomainStringValidationUtil.titleStringNullException(title)) {
+            str = DomainStringValidationUtil.stringSettingTrim(title);
+        }
+
+        return new Title(str);
+    }
+}

--- a/src/main/java/com/example/yun/domain/board/Title.java
+++ b/src/main/java/com/example/yun/domain/board/Title.java
@@ -1,11 +1,12 @@
 package com.example.yun.domain.board;
 
-import com.example.yun.util.DomainStringValidationUtil;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
+
+import static com.example.yun.util.board.BoardValidationUtil.*;
 
 @Embeddable
 @Getter
@@ -21,8 +22,8 @@ public class Title {
     public static Title titleCreate(String title) {
         String str = "";
 
-        if(DomainStringValidationUtil.titleStringNullException(title)) {
-            str = DomainStringValidationUtil.stringSettingTrim(title);
+        if(titleStringNullException(title)) {
+            str = stringSettingTrim(title);
         }
 
         return new Title(str);

--- a/src/main/java/com/example/yun/domain/member/Email.java
+++ b/src/main/java/com/example/yun/domain/member/Email.java
@@ -1,0 +1,30 @@
+package com.example.yun.domain.member;
+
+import com.example.yun.util.member.MemberValidationUtil;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+import static com.example.yun.util.member.MemberValidationUtil.*;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Email {
+
+    private String email;
+
+    private Email(String email) {
+        this.email = email;
+    }
+
+    public static Email emailCreate(String email) {
+        if(emailValidationCheck(email)) {
+            return new Email(email);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/example/yun/domain/member/Member.java
+++ b/src/main/java/com/example/yun/domain/member/Member.java
@@ -1,0 +1,38 @@
+package com.example.yun.domain.member;
+
+import com.example.yun.domain.BaseEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id @GeneratedValue
+    private Long id;
+    private Email email;
+    private Password password;
+
+    private Member(final String email, final String password) {
+        this.email = Email.emailCreate(email);
+        this.password = Password.pwdCreate(password);
+    }
+
+    public static Member create(String email, String password) {
+        return new Member(email, password);
+    }
+
+    public String getPassword() {
+        return password.getPassword();
+    }
+
+    public String getEmail() {
+        return email.getEmail();
+    }
+}

--- a/src/main/java/com/example/yun/domain/member/Password.java
+++ b/src/main/java/com/example/yun/domain/member/Password.java
@@ -1,0 +1,29 @@
+package com.example.yun.domain.member;
+
+import com.example.yun.util.member.MemberValidationUtil;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+import static com.example.yun.util.member.MemberValidationUtil.*;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Password {
+
+    private String password;
+
+    private Password(String password) {
+        this.password = password;
+    }
+
+    public static Password pwdCreate(String password) {
+        if(pwdValidationCheck(password)) {
+            return new Password(password);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/yun/dto/BoardRequestDto.java
+++ b/src/main/java/com/example/yun/dto/BoardRequestDto.java
@@ -1,17 +1,14 @@
 package com.example.yun.dto;
 
 import io.swagger.annotations.ApiModelProperty;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class BoardRequestDto {
 
     @NotBlank
@@ -23,4 +20,18 @@ public class BoardRequestDto {
     @Size(max = 1000)
     @ApiModelProperty(value = "내용", example = "ㅎㅇ요", required = true)
     private String content;
+
+    @Email
+    @ApiModelProperty(value = "이메일", example = "sawew1234@google.com", required = true)
+    private String email;
+
+    private BoardRequestDto(final String title, final String content, final String email) {
+        this.title = title;
+        this.content = content;
+        this.email = email;
+    }
+
+    public static BoardRequestDto boardRequestCreate(final String title, final String content, final String email) {
+        return new BoardRequestDto(title, content, email);
+    }
 }

--- a/src/main/java/com/example/yun/dto/BoardResponseDto.java
+++ b/src/main/java/com/example/yun/dto/BoardResponseDto.java
@@ -1,14 +1,15 @@
 package com.example.yun.dto;
 
 import com.example.yun.domain.board.Board;
+import com.example.yun.domain.board.Content;
+import com.example.yun.domain.board.Title;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
-import static java.util.stream.Collectors.toList;
+import static com.example.yun.domain.board.Content.*;
+import static com.example.yun.domain.board.Title.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/yun/dto/comment/CommentRequestDto.java
+++ b/src/main/java/com/example/yun/dto/comment/CommentRequestDto.java
@@ -1,0 +1,24 @@
+package com.example.yun.dto.comment;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentRequestDto {
+
+    private String content;
+    private String email;
+    private Long boardId;
+
+    private CommentRequestDto(String content, String email, Long boardId) {
+        this.content = content;
+        this.email = email;
+        this.boardId = boardId;
+    }
+
+    public static CommentRequestDto commentRequestCreate(String content, String email, Long boardId) {
+        return new CommentRequestDto(content, email, boardId);
+    }
+}

--- a/src/main/java/com/example/yun/dto/comment/CommentRequestDto.java
+++ b/src/main/java/com/example/yun/dto/comment/CommentRequestDto.java
@@ -4,21 +4,21 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Email;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentRequestDto {
 
     private String content;
-    private String email;
     private Long boardId;
 
-    private CommentRequestDto(String content, String email, Long boardId) {
+    private CommentRequestDto(String content, Long boardId) {
         this.content = content;
-        this.email = email;
         this.boardId = boardId;
     }
 
-    public static CommentRequestDto commentRequestCreate(String content, String email, Long boardId) {
-        return new CommentRequestDto(content, email, boardId);
+    public static CommentRequestDto commentRequestCreate(String content, Long boardId) {
+        return new CommentRequestDto(content, boardId);
     }
 }

--- a/src/main/java/com/example/yun/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/example/yun/dto/comment/CommentResponseDto.java
@@ -1,0 +1,25 @@
+package com.example.yun.dto.comment;
+
+import com.example.yun.domain.Comment.Comment;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentResponseDto {
+
+    private String content;
+    private LocalDateTime createTime;
+
+    private CommentResponseDto(String content, LocalDateTime createTime) {
+        this.content = content;
+        this.createTime = createTime;
+    }
+
+    public static CommentResponseDto commentResponseCreate(Comment comment) {
+        return new CommentResponseDto(comment.getContent(), comment.getCreateTime());
+    }
+}

--- a/src/main/java/com/example/yun/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/example/yun/dto/comment/CommentResponseDto.java
@@ -11,15 +11,17 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CommentResponseDto {
 
+    private Long id;
     private String content;
     private LocalDateTime createTime;
 
-    private CommentResponseDto(String content, LocalDateTime createTime) {
+    private CommentResponseDto(Long id, String content, LocalDateTime createTime) {
+        this.id = id;
         this.content = content;
         this.createTime = createTime;
     }
 
     public static CommentResponseDto commentResponseCreate(Comment comment) {
-        return new CommentResponseDto(comment.getContent(), comment.getCreateTime());
+        return new CommentResponseDto(comment.getId(), comment.getContent(), comment.getCreateTime());
     }
 }

--- a/src/main/java/com/example/yun/dto/member/MemberRequestDto.java
+++ b/src/main/java/com/example/yun/dto/member/MemberRequestDto.java
@@ -1,15 +1,11 @@
 package com.example.yun.dto.member;
 
-import com.example.yun.util.member.MemberValidationUtil;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
-
-import static com.example.yun.util.member.MemberValidationUtil.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/yun/dto/member/MemberRequestDto.java
+++ b/src/main/java/com/example/yun/dto/member/MemberRequestDto.java
@@ -1,0 +1,22 @@
+package com.example.yun.dto.member;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberRequestDto {
+
+    private String email;
+    private String password;
+
+    private MemberRequestDto(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public static MemberRequestDto create(String email, String password) {
+        return new MemberRequestDto(email, password);
+    }
+}

--- a/src/main/java/com/example/yun/dto/member/MemberResponseDto.java
+++ b/src/main/java/com/example/yun/dto/member/MemberResponseDto.java
@@ -1,0 +1,27 @@
+package com.example.yun.dto.member;
+
+import com.example.yun.domain.member.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberResponseDto {
+
+    private Long id;
+    private String email;
+    private LocalDateTime createTime;
+
+    private MemberResponseDto(Long id, String email, LocalDateTime createTime) {
+        this.id = id;
+        this.email = email;
+        this.createTime = createTime;
+    }
+
+    public static MemberResponseDto create(Member member) {
+        return new MemberResponseDto(member.getId(), member.getEmail(), member.getCreateTime());
+    }
+}

--- a/src/main/java/com/example/yun/dto/member/login/LoginRequestDto.java
+++ b/src/main/java/com/example/yun/dto/member/login/LoginRequestDto.java
@@ -1,31 +1,27 @@
-package com.example.yun.dto.member;
+package com.example.yun.dto.member.login;
 
-import com.example.yun.util.member.MemberValidationUtil;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.Pattern;
 
-import static com.example.yun.util.member.MemberValidationUtil.*;
-
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MemberRequestDto {
+public class LoginRequestDto {
 
     @Email
     private String email;
     @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$")
     private String password;
 
-    private MemberRequestDto(String email, String password) {
+    private LoginRequestDto(String email, String password) {
         this.email = email;
         this.password = password;
     }
 
-    public static MemberRequestDto create(String email, String password) {
-        return new MemberRequestDto(email, password);
+    public static LoginRequestDto create(String email, String pwd) {
+        return new LoginRequestDto(email, pwd);
     }
 }

--- a/src/main/java/com/example/yun/dto/member/login/LoginResponseDto.java
+++ b/src/main/java/com/example/yun/dto/member/login/LoginResponseDto.java
@@ -1,0 +1,20 @@
+package com.example.yun.dto.member.login;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginResponseDto {
+
+    private String accessToken;
+
+    private LoginResponseDto(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public static LoginResponseDto create(String accessToken) {
+        return new LoginResponseDto(accessToken);
+    }
+}

--- a/src/main/java/com/example/yun/dto/update/BoardContentUpdateDto.java
+++ b/src/main/java/com/example/yun/dto/update/BoardContentUpdateDto.java
@@ -20,4 +20,6 @@ public class BoardContentUpdateDto {
     @Size(max = 1000)
     @ApiModelProperty(value = "내용", example = "ㅎㅇ요", required = true)
     private String content;
+
+
 }

--- a/src/main/java/com/example/yun/exception/ExceptionControl.java
+++ b/src/main/java/com/example/yun/exception/ExceptionControl.java
@@ -1,0 +1,27 @@
+package com.example.yun.exception;
+
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+public enum ExceptionControl {
+
+    NOT_FOUND_MEMBER(NOT_FOUND,"회원을 찾을 수 없습니다."),
+    NOT_FOUND_BOARD(NOT_FOUND,"게시물을 찾을 수 없습니다.");
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    ExceptionControl(HttpStatus httpStatus, String message) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/example/yun/exception/NotFoundBoardException.java
+++ b/src/main/java/com/example/yun/exception/NotFoundBoardException.java
@@ -1,0 +1,19 @@
+package com.example.yun.exception;
+
+public class NotFoundBoardException extends IllegalArgumentException {
+
+    public NotFoundBoardException() {
+    }
+
+    public NotFoundBoardException(String s) {
+        super(s);
+    }
+
+    public NotFoundBoardException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotFoundBoardException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/example/yun/exception/NotFoundMemberException.java
+++ b/src/main/java/com/example/yun/exception/NotFoundMemberException.java
@@ -1,0 +1,19 @@
+package com.example.yun.exception;
+
+public class NotFoundMemberException extends IllegalArgumentException {
+
+    public NotFoundMemberException() {
+    }
+
+    public NotFoundMemberException(String s) {
+        super(s);
+    }
+
+    public NotFoundMemberException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public NotFoundMemberException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/example/yun/exception/StringValidationException.java
+++ b/src/main/java/com/example/yun/exception/StringValidationException.java
@@ -1,0 +1,19 @@
+package com.example.yun.exception;
+
+public class StringValidationException extends IllegalArgumentException {
+
+    public StringValidationException() {
+    }
+
+    public StringValidationException(String s) {
+        super(s);
+    }
+
+    public StringValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public StringValidationException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/com/example/yun/interceptor/BaseInterceptor.java
+++ b/src/main/java/com/example/yun/interceptor/BaseInterceptor.java
@@ -1,21 +1,18 @@
 package com.example.yun.interceptor;
 
-import com.example.yun.util.jwt.JwtUtil;
-import com.example.yun.util.member.LoginCheckUtil;
+import com.example.yun.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import static com.example.yun.util.jwt.JwtUtil.*;
-
 @Slf4j
 @RequiredArgsConstructor
 public class BaseInterceptor implements HandlerInterceptor {
+
+    private final JwtProvider jwtProvider;
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -24,6 +21,6 @@ public class BaseInterceptor implements HandlerInterceptor {
 
         String token = request.getHeader("Authorization");
 
-        return tokenExpiredCheck(token);
+        return jwtProvider.tokenExpiredCheck(token);
     }
 }

--- a/src/main/java/com/example/yun/interceptor/BaseInterceptor.java
+++ b/src/main/java/com/example/yun/interceptor/BaseInterceptor.java
@@ -1,0 +1,29 @@
+package com.example.yun.interceptor;
+
+import com.example.yun.util.jwt.JwtUtil;
+import com.example.yun.util.member.LoginCheckUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static com.example.yun.util.jwt.JwtUtil.*;
+
+@Slf4j
+@RequiredArgsConstructor
+public class BaseInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        log.info("[request] = {}", request);
+        log.info("[response] = {}", response);
+
+        String token = request.getHeader("Authorization");
+
+        return tokenExpiredCheck(token);
+    }
+}

--- a/src/main/java/com/example/yun/jwt/JwtObject.java
+++ b/src/main/java/com/example/yun/jwt/JwtObject.java
@@ -1,0 +1,23 @@
+package com.example.yun.jwt;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JwtObject {
+
+    private Long id;
+    private String email;
+
+    private JwtObject(Long id, String email) {
+        this.id = id;
+        this.email = email;
+    }
+
+    public static JwtObject create(Long id, String email) {
+        return new JwtObject(id, email);
+    }
+}

--- a/src/main/java/com/example/yun/jwt/JwtObject.java
+++ b/src/main/java/com/example/yun/jwt/JwtObject.java
@@ -10,14 +10,12 @@ import lombok.NoArgsConstructor;
 public class JwtObject {
 
     private Long id;
-    private String email;
 
-    private JwtObject(Long id, String email) {
+    private JwtObject(Long id) {
         this.id = id;
-        this.email = email;
     }
 
-    public static JwtObject create(Long id, String email) {
-        return new JwtObject(id, email);
+    public static JwtObject create(Long id) {
+        return new JwtObject(id);
     }
 }

--- a/src/main/java/com/example/yun/jwt/JwtProvider.java
+++ b/src/main/java/com/example/yun/jwt/JwtProvider.java
@@ -1,64 +1,50 @@
 package com.example.yun.jwt;
 
 import com.example.yun.domain.member.Member;
-import com.example.yun.repository.querydsl.MemberQueryRepository;
-import com.example.yun.service.MemberService;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.example.yun.util.jwt.JwtUtil;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
-import javax.naming.AuthenticationException;
-import java.security.Key;
-import java.util.Base64;
 import java.util.Date;
 
 import static com.example.yun.util.jwt.JwtUtil.getFormatToken;
 
-@Component
 @Slf4j
-@RequiredArgsConstructor
+@Component
 public class JwtProvider {
 
-    private final MemberQueryRepository memberQueryRepository;
-    private final ObjectMapper objectMapper;
+    private final Long accessExpireTime;
+    private final String key;
 
-    @Value("${jwt.key}")
-    private String key;
-    @Value("${jwt.expireTime.access}")
-    private Long accessExpireTime;
+    public JwtProvider(@Value("${jwt.key}") String key,
+                       @Value("${jwt.expireTime.access}") Long accessExpireTime) {
 
-    @PostConstruct
-    void init() {
-        key = Base64.getEncoder().encodeToString(key.getBytes());
+        log.info("[key] = {}, [expireTime] = {}", key, accessExpireTime);
+
+        this.accessExpireTime = accessExpireTime;
+        this.key = JwtUtil.getSigningKey(key);
     }
 
-    public String createToken(String email) throws JsonProcessingException {
-        return createTokenLogic(email, accessExpireTime);
+    public String createToken(Member member) {
+        return createTokenLogic(member, accessExpireTime);
     }
 
     /**
      * 토큰 생성
-     * @param email 유저 이메일
+     * @param member 유저
      * @param expireTime 토큰 만료기간
      * @return token
-     * @throws JsonProcessingException
      */
-    private String createTokenLogic(String email, Long expireTime) throws JsonProcessingException {
+    private String createTokenLogic(Member member, Long expireTime) {
 
-        Member member = memberQueryRepository.findMemberByEmail(email);
+        Claims claims = Jwts.claims();
+        claims.put("id", member.getId());
 
-        String stringObject = objectMapper.writeValueAsString(JwtObject.create(member.getId(), member.getEmail()));
-
-        Claims claims = Jwts.claims().setSubject(stringObject);
         Date date = new Date();
 
         return Jwts.builder()
@@ -69,12 +55,10 @@ public class JwtProvider {
                 .compact();
     }
 
-    public JwtObject tokenPayloadExtract(String jwt) throws JsonProcessingException {
+    public String tokenPayloadExtract(String jwt) {
         String token = getFormatToken(jwt);
 
-        String subject = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody().getSubject();
-
-        return objectMapper.readValue(subject, JwtObject.class);
+        return Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody().get("id").toString();
     }
 
     /**
@@ -82,11 +66,11 @@ public class JwtProvider {
      * @param jwt 토큰
      * @return 유효성 통과 true, 실패 false
      */
-    public boolean tokenExpiredCheck(String jwt) throws AuthenticationException {
+    public boolean tokenExpiredCheck(String jwt) {
         String token = getFormatToken(jwt);
 
         if(token == null || token.equals(""))
-            throw new AuthenticationException("jwt is null!!");
+            return false;
 
         try {
             Claims claims = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody();

--- a/src/main/java/com/example/yun/jwt/JwtProvider.java
+++ b/src/main/java/com/example/yun/jwt/JwtProvider.java
@@ -6,16 +6,22 @@ import com.example.yun.service.MemberService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
+import javax.naming.AuthenticationException;
+import java.security.Key;
 import java.util.Base64;
 import java.util.Date;
+
+import static com.example.yun.util.jwt.JwtUtil.getFormatToken;
 
 @Component
 @Slf4j
@@ -27,10 +33,6 @@ public class JwtProvider {
 
     @Value("${jwt.key}")
     private String key;
-
-    @Value("${jwt.blackList}")
-    private String blackList;
-
     @Value("${jwt.expireTime.access}")
     private Long accessExpireTime;
 
@@ -67,4 +69,34 @@ public class JwtProvider {
                 .compact();
     }
 
+    public JwtObject tokenPayloadExtract(String jwt) throws JsonProcessingException {
+        String token = getFormatToken(jwt);
+
+        String subject = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody().getSubject();
+
+        return objectMapper.readValue(subject, JwtObject.class);
+    }
+
+    /**
+     * 토큰 유효성, 만료 체크
+     * @param jwt 토큰
+     * @return 유효성 통과 true, 실패 false
+     */
+    public boolean tokenExpiredCheck(String jwt) throws AuthenticationException {
+        String token = getFormatToken(jwt);
+
+        if(token == null || token.equals(""))
+            throw new AuthenticationException("jwt is null!!");
+
+        try {
+            Claims claims = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody();
+            log.info("[expireTime] = {}", claims.getExpiration());
+            log.info("[subject] = {}", claims.getSubject());
+        } catch (JwtException | NullPointerException e) {
+            log.error("token error!!");
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/main/java/com/example/yun/jwt/JwtProvider.java
+++ b/src/main/java/com/example/yun/jwt/JwtProvider.java
@@ -2,10 +2,13 @@ package com.example.yun.jwt;
 
 import com.example.yun.domain.member.Member;
 import com.example.yun.util.jwt.JwtUtil;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -82,5 +85,12 @@ public class JwtProvider {
         }
 
         return true;
+    }
+
+    public Long mapTokenToId(String token) {
+
+        String s = tokenPayloadExtract(token);
+
+        return Long.parseLong(s);
     }
 }

--- a/src/main/java/com/example/yun/jwt/JwtProvider.java
+++ b/src/main/java/com/example/yun/jwt/JwtProvider.java
@@ -1,0 +1,69 @@
+package com.example.yun.jwt;
+
+import com.example.yun.domain.member.Member;
+import com.example.yun.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ser.Serializers;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final MemberService memberService;
+    private final ObjectMapper objectMapper;
+
+    @Value("${jwt.key}")
+    private String key;
+
+    @Value("${jwt.blackList}")
+    private String blackList;
+
+    @Value("${jwt.expireTime.access}")
+    private Long accessExpireTime;
+
+    @PostConstruct
+    void init() {
+        key = Base64.getEncoder().encodeToString(key.getBytes());
+    }
+
+    /**
+     * 토큰 생성
+     * @param email 유저 이메일
+     * @param expireTime 토큰 만료기간
+     * @return token
+     * @throws JsonProcessingException
+     */
+    public String createToken(String email, Long expireTime) throws JsonProcessingException {
+
+        Member member = memberService.findMember(email);
+
+        String stringObject = objectMapper.writeValueAsString(JwtObject.create(member.getId(), member.getEmail()));
+
+        Claims claims = Jwts.claims().setSubject(stringObject);
+        Date date = new Date();
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(date)
+                .setExpiration(new Date(date.getTime() + expireTime))
+                .signWith(SignatureAlgorithm.HS256, key)
+                .compact();
+    }
+
+}

--- a/src/main/java/com/example/yun/jwt/JwtProvider.java
+++ b/src/main/java/com/example/yun/jwt/JwtProvider.java
@@ -1,22 +1,19 @@
 package com.example.yun.jwt;
 
 import com.example.yun.domain.member.Member;
+import com.example.yun.repository.querydsl.MemberQueryRepository;
 import com.example.yun.service.MemberService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ser.Serializers;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDateTime;
 import java.util.Base64;
 import java.util.Date;
 
@@ -25,7 +22,7 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtProvider {
 
-    private final MemberService memberService;
+    private final MemberQueryRepository memberQueryRepository;
     private final ObjectMapper objectMapper;
 
     @Value("${jwt.key}")
@@ -42,6 +39,10 @@ public class JwtProvider {
         key = Base64.getEncoder().encodeToString(key.getBytes());
     }
 
+    public String createToken(String email) throws JsonProcessingException {
+        return createTokenLogic(email, accessExpireTime);
+    }
+
     /**
      * 토큰 생성
      * @param email 유저 이메일
@@ -49,9 +50,9 @@ public class JwtProvider {
      * @return token
      * @throws JsonProcessingException
      */
-    public String createToken(String email, Long expireTime) throws JsonProcessingException {
+    private String createTokenLogic(String email, Long expireTime) throws JsonProcessingException {
 
-        Member member = memberService.findMember(email);
+        Member member = memberQueryRepository.findMemberByEmail(email);
 
         String stringObject = objectMapper.writeValueAsString(JwtObject.create(member.getId(), member.getEmail()));
 

--- a/src/main/java/com/example/yun/repository/comment/CommentRepository.java
+++ b/src/main/java/com/example/yun/repository/comment/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.example.yun.repository.comment;
+
+import com.example.yun.domain.Comment.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/example/yun/repository/member/MemberRepository.java
+++ b/src/main/java/com/example/yun/repository/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.example.yun.repository.member;
+
+import com.example.yun.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/example/yun/repository/querydsl/CommentQueryRepository.java
+++ b/src/main/java/com/example/yun/repository/querydsl/CommentQueryRepository.java
@@ -1,0 +1,12 @@
+package com.example.yun.repository.querydsl;
+
+import com.example.yun.domain.Comment.Comment;
+
+import java.util.List;
+
+public interface CommentQueryRepository {
+
+    default List<Comment> findCommentsByBoardId(Long boardId) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/yun/repository/querydsl/MemberQueryRepository.java
+++ b/src/main/java/com/example/yun/repository/querydsl/MemberQueryRepository.java
@@ -2,13 +2,15 @@ package com.example.yun.repository.querydsl;
 
 import com.example.yun.domain.member.Member;
 
+import java.util.Optional;
+
 public interface MemberQueryRepository {
 
     default boolean duplicatedEmailCheck(String email) {
         return false;
     }
 
-    default Member findMemberByEmail(String email) {
-        return null;
+    default Optional<Member> findMemberByEmail(String email) {
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/example/yun/repository/querydsl/MemberQueryRepository.java
+++ b/src/main/java/com/example/yun/repository/querydsl/MemberQueryRepository.java
@@ -1,0 +1,14 @@
+package com.example.yun.repository.querydsl;
+
+import com.example.yun.domain.member.Member;
+
+public interface MemberQueryRepository {
+
+    default boolean duplicatedEmailCheck(String email) {
+        return false;
+    }
+
+    default Member findMemberByEmail(String email) {
+        return null;
+    }
+}

--- a/src/main/java/com/example/yun/repository/querydsl/impl/BoardQueryDslRepositoryImpl.java
+++ b/src/main/java/com/example/yun/repository/querydsl/impl/BoardQueryDslRepositoryImpl.java
@@ -27,7 +27,7 @@ public class BoardQueryDslRepositoryImpl implements BoardQueryRepository {
     @Override
     public List<Board> boardSearchByKeyword(String keyword) {
         return jpaQueryFactory.selectFrom(board)
-                .where(board.title.contains(keyword))
+                .where(board.title.title.contains(keyword))
                 .orderBy(board.createTime.desc())
                 .limit(100L)
                 .fetch();

--- a/src/main/java/com/example/yun/repository/querydsl/impl/CommentQueryDslRepositoryImpl.java
+++ b/src/main/java/com/example/yun/repository/querydsl/impl/CommentQueryDslRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.example.yun.repository.querydsl.impl;
 
 import com.example.yun.domain.Comment.Comment;
+import com.example.yun.domain.member.QMember;
 import com.example.yun.repository.querydsl.CommentQueryRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import java.util.List;
 
 import static com.example.yun.domain.Comment.QComment.*;
 import static com.example.yun.domain.board.QBoard.*;
+import static com.example.yun.domain.member.QMember.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -22,6 +24,7 @@ public class CommentQueryDslRepositoryImpl implements CommentQueryRepository {
         return jpaQueryFactory.selectFrom(comment)
                 .where(comment.board.id.eq(boardId))
                 .join(comment.board, board).fetchJoin()
+                .join(comment.member, member).fetchJoin()
                 .fetch();
     }
 }

--- a/src/main/java/com/example/yun/repository/querydsl/impl/CommentQueryDslRepositoryImpl.java
+++ b/src/main/java/com/example/yun/repository/querydsl/impl/CommentQueryDslRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.example.yun.repository.querydsl.impl;
+
+import com.example.yun.domain.Comment.Comment;
+import com.example.yun.repository.querydsl.CommentQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.example.yun.domain.Comment.QComment.*;
+import static com.example.yun.domain.board.QBoard.*;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentQueryDslRepositoryImpl implements CommentQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Comment> findCommentsByBoardId(Long boardId) {
+        return jpaQueryFactory.selectFrom(comment)
+                .where(comment.board.id.eq(boardId))
+                .join(comment.board, board).fetchJoin()
+                .fetch();
+    }
+}

--- a/src/main/java/com/example/yun/repository/querydsl/impl/MemberQueryDslRepositoryImpl.java
+++ b/src/main/java/com/example/yun/repository/querydsl/impl/MemberQueryDslRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.example.yun.repository.querydsl.impl;
+
+import com.example.yun.domain.member.Member;
+import com.example.yun.domain.member.QMember;
+import com.example.yun.repository.querydsl.MemberQueryRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import static com.example.yun.domain.member.QMember.*;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberQueryDslRepositoryImpl implements MemberQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public boolean duplicatedEmailCheck(String email) {
+        return jpaQueryFactory.selectFrom(member)
+                .where(member.email.email.eq(email))
+                .fetchFirst() != null;
+    }
+
+    @Override
+    public Member findMemberByEmail(String email) {
+        return jpaQueryFactory.selectFrom(member)
+                .where(member.email.email.eq(email))
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/example/yun/repository/querydsl/impl/MemberQueryDslRepositoryImpl.java
+++ b/src/main/java/com/example/yun/repository/querydsl/impl/MemberQueryDslRepositoryImpl.java
@@ -7,7 +7,10 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 import static com.example.yun.domain.member.QMember.*;
+import static java.util.Optional.*;
 
 @Repository
 @RequiredArgsConstructor
@@ -23,9 +26,9 @@ public class MemberQueryDslRepositoryImpl implements MemberQueryRepository {
     }
 
     @Override
-    public Member findMemberByEmail(String email) {
-        return jpaQueryFactory.selectFrom(member)
+    public Optional<Member> findMemberByEmail(String email) {
+        return ofNullable(jpaQueryFactory.selectFrom(member)
                 .where(member.email.email.eq(email))
-                .fetchOne();
+                .fetchOne());
     }
 }

--- a/src/main/java/com/example/yun/service/BoardService.java
+++ b/src/main/java/com/example/yun/service/BoardService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface BoardService {
 
-    default BoardResponseDto boardCreate(String title, String content) {
+    default BoardResponseDto boardCreate(String title, String content, String email) {
         return null;
     }
 

--- a/src/main/java/com/example/yun/service/CommentService.java
+++ b/src/main/java/com/example/yun/service/CommentService.java
@@ -1,0 +1,21 @@
+package com.example.yun.service;
+
+import com.example.yun.dto.comment.CommentResponseDto;
+
+import java.util.List;
+
+public interface CommentService {
+
+    default CommentResponseDto commentCreate(Long boardId, String email, String content) {
+        return null;
+    }
+
+    default List<CommentResponseDto> findCommentsBoardById(Long boardId) {
+        return null;
+    }
+
+    default CommentResponseDto updateComment(Long boardId, String updateContent) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/example/yun/service/CommentService.java
+++ b/src/main/java/com/example/yun/service/CommentService.java
@@ -1,12 +1,13 @@
 package com.example.yun.service;
 
 import com.example.yun.dto.comment.CommentResponseDto;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.List;
 
 public interface CommentService {
 
-    default CommentResponseDto commentCreate(Long boardId, String email, String content) {
+    default CommentResponseDto commentCreate(Long boardId, String jwt, String content) throws JsonProcessingException {
         return null;
     }
 
@@ -15,6 +16,10 @@ public interface CommentService {
     }
 
     default CommentResponseDto updateComment(Long boardId, String updateContent) {
+        return null;
+    }
+
+    default String deleteComment(Long comment) {
         return null;
     }
 

--- a/src/main/java/com/example/yun/service/MemberService.java
+++ b/src/main/java/com/example/yun/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.example.yun.service;
 
 import com.example.yun.domain.member.Member;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 public interface MemberService {
 
@@ -8,15 +9,15 @@ public interface MemberService {
         return null;
     }
 
-    default String login(String email, String pwd) {
+    default String login(String email, String pwd) throws JsonProcessingException {
         return null;
     }
 
-    default String logout(String email) {
+    default String logout(String email, String jwt) {
         return null;
     }
 
-    default Member findMember(String email) {
+    default Member findMember(Long id) {
         return null;
     }
 

--- a/src/main/java/com/example/yun/service/MemberService.java
+++ b/src/main/java/com/example/yun/service/MemberService.java
@@ -1,0 +1,23 @@
+package com.example.yun.service;
+
+import com.example.yun.domain.member.Member;
+
+public interface MemberService {
+
+    default Member memberCreate(String email, String pwd) {
+        return null;
+    }
+
+    default String login(String email, String pwd) {
+        return null;
+    }
+
+    default String logout(String email) {
+        return null;
+    }
+
+    default Member findMember(String email) {
+        return null;
+    }
+
+}

--- a/src/main/java/com/example/yun/service/MemberService.java
+++ b/src/main/java/com/example/yun/service/MemberService.java
@@ -9,7 +9,7 @@ public interface MemberService {
         return null;
     }
 
-    default String login(String email, String pwd) throws JsonProcessingException {
+    default String login(String email, String pwd) {
         return null;
     }
 
@@ -17,7 +17,7 @@ public interface MemberService {
         return null;
     }
 
-    default Member findMember(Long id) {
+    default Member findMember(String jwt) throws JsonProcessingException {
         return null;
     }
 

--- a/src/main/java/com/example/yun/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/example/yun/service/impl/BoardServiceImpl.java
@@ -1,10 +1,13 @@
 package com.example.yun.service.impl;
 
 import com.example.yun.domain.board.Board;
+import com.example.yun.domain.member.Member;
 import com.example.yun.dto.BoardResponseDto;
 import com.example.yun.exception.BoardMessage;
 import com.example.yun.repository.BoardRepository;
+import com.example.yun.repository.member.MemberRepository;
 import com.example.yun.repository.querydsl.BoardQueryRepository;
+import com.example.yun.repository.querydsl.MemberQueryRepository;
 import com.example.yun.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,17 +30,24 @@ public class BoardServiceImpl implements BoardService {
 
     private final BoardRepository boardRepository;
     private final BoardQueryRepository boardQueryRepository;
+    private final MemberQueryRepository memberQueryRepository;
 
     /**
      * 게시물 등록
-     * @param title 제목
+     *
+     * @param title   제목
      * @param content 내용
+     * @param email 유저 이메일
      * @return 게시물 응답 Dto(id, title, content)
      */
     @Override
     @Transactional
-    public BoardResponseDto boardCreate(String title, String content) {
-        Board board = Board.create(title, content);
+    public BoardResponseDto boardCreate(String title, String content, String email) {
+
+        Member member = memberQueryRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        Board board = Board.create(title, content, member);
 
         Board save = boardRepository.save(board);
 

--- a/src/main/java/com/example/yun/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/example/yun/service/impl/BoardServiceImpl.java
@@ -5,7 +5,6 @@ import com.example.yun.domain.member.Member;
 import com.example.yun.dto.BoardResponseDto;
 import com.example.yun.exception.BoardMessage;
 import com.example.yun.repository.BoardRepository;
-import com.example.yun.repository.member.MemberRepository;
 import com.example.yun.repository.querydsl.BoardQueryRepository;
 import com.example.yun.repository.querydsl.MemberQueryRepository;
 import com.example.yun.service.BoardService;

--- a/src/main/java/com/example/yun/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/example/yun/service/impl/BoardServiceImpl.java
@@ -37,7 +37,7 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional
     public BoardResponseDto boardCreate(String title, String content) {
-        Board board = new Board(titleCreate(title), contentCreate(content));
+        Board board = Board.create(title, content);
 
         Board save = boardRepository.save(board);
 

--- a/src/main/java/com/example/yun/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/example/yun/service/impl/BoardServiceImpl.java
@@ -2,9 +2,9 @@ package com.example.yun.service.impl;
 
 import com.example.yun.domain.board.Board;
 import com.example.yun.dto.BoardResponseDto;
+import com.example.yun.exception.BoardMessage;
 import com.example.yun.repository.BoardRepository;
 import com.example.yun.repository.querydsl.BoardQueryRepository;
-import com.example.yun.exception.BoardMessage;
 import com.example.yun.service.BoardService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+import static com.example.yun.domain.board.Content.contentCreate;
+import static com.example.yun.domain.board.Title.titleCreate;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toList;
 
@@ -35,7 +37,7 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional
     public BoardResponseDto boardCreate(String title, String content) {
-        Board board = new Board(title, content);
+        Board board = new Board(titleCreate(title), contentCreate(content));
 
         Board save = boardRepository.save(board);
 
@@ -84,7 +86,7 @@ public class BoardServiceImpl implements BoardService {
 
         log.info("board = {}", board.get());
 
-        getBoard(board).updateTitle(title);
+        getBoard(board).updateTitle(titleCreate(title));
 
         Optional<Board> updateBoard = getBoard(id);
 
@@ -106,7 +108,7 @@ public class BoardServiceImpl implements BoardService {
 
         log.info("board = {}", board.get());
 
-        getBoard(board).updateContent(content);
+        getBoard(board).updateContent(contentCreate(content));
 
         Optional<Board> updateContent = getBoard(id);
 

--- a/src/main/java/com/example/yun/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/example/yun/service/impl/CommentServiceImpl.java
@@ -4,20 +4,26 @@ import com.example.yun.domain.Comment.Comment;
 import com.example.yun.domain.board.Board;
 import com.example.yun.domain.member.Member;
 import com.example.yun.dto.comment.CommentResponseDto;
+import com.example.yun.exception.NotFoundBoardException;
+import com.example.yun.exception.NotFoundMemberException;
+import com.example.yun.jwt.JwtObject;
+import com.example.yun.jwt.JwtProvider;
 import com.example.yun.repository.BoardRepository;
 import com.example.yun.repository.comment.CommentRepository;
 import com.example.yun.repository.member.MemberRepository;
 import com.example.yun.repository.querydsl.CommentQueryRepository;
 import com.example.yun.repository.querydsl.MemberQueryRepository;
 import com.example.yun.service.CommentService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static java.util.stream.Collectors.*;
+import static com.example.yun.exception.ExceptionControl.*;
+import static java.util.stream.Collectors.toList;
 
 @Service
 @RequiredArgsConstructor
@@ -27,17 +33,20 @@ public class CommentServiceImpl implements CommentService {
     private final CommentRepository commentRepository;
     private final CommentQueryRepository commentQueryRepository;
     private final BoardRepository boardRepository;
-    private final MemberQueryRepository memberQueryRepository;
+    private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
 
     @Override
     @Transactional
-    public CommentResponseDto commentCreate(Long boardId, String email, String content) {
+    public CommentResponseDto commentCreate(Long boardId, String jwt, String content) {
 
-        Member member = memberQueryRepository.findMemberByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+        Long userId = jwtProvider.mapTokenToId(jwt);
+
+        Member member = memberRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundMemberException(NOT_FOUND_MEMBER.getMessage()));
 
         Board board = boardRepository.findById(boardId)
-                .orElseThrow(() -> new IllegalArgumentException("게시물을 찾을 수 없습니다."));
+                .orElseThrow(() -> new NotFoundBoardException(NOT_FOUND_BOARD.getMessage()));
 
         Comment comment = Comment.commentCreate(content, member, board);
 
@@ -48,15 +57,14 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     public List<CommentResponseDto> findCommentsBoardById(Long boardId) {
-        List<Comment> comments = commentQueryRepository.findCommentsByBoardId(boardId);
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new NotFoundBoardException(NOT_FOUND_BOARD.getMessage()));
+
+        List<Comment> comments = commentQueryRepository.findCommentsByBoardId(board.getId());
 
         return comments.stream().map(CommentResponseDto::commentResponseCreate)
                 .collect(toList());
     }
 
-    @Override
-    @Transactional
-    public CommentResponseDto updateComment(Long boardId, String updateContent) {
-        return CommentService.super.updateComment(boardId, updateContent);
-    }
 }

--- a/src/main/java/com/example/yun/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/example/yun/service/impl/CommentServiceImpl.java
@@ -1,0 +1,62 @@
+package com.example.yun.service.impl;
+
+import com.example.yun.domain.Comment.Comment;
+import com.example.yun.domain.board.Board;
+import com.example.yun.domain.member.Member;
+import com.example.yun.dto.comment.CommentResponseDto;
+import com.example.yun.repository.BoardRepository;
+import com.example.yun.repository.comment.CommentRepository;
+import com.example.yun.repository.member.MemberRepository;
+import com.example.yun.repository.querydsl.CommentQueryRepository;
+import com.example.yun.repository.querydsl.MemberQueryRepository;
+import com.example.yun.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentServiceImpl implements CommentService {
+
+    private final CommentRepository commentRepository;
+    private final CommentQueryRepository commentQueryRepository;
+    private final BoardRepository boardRepository;
+    private final MemberQueryRepository memberQueryRepository;
+
+    @Override
+    @Transactional
+    public CommentResponseDto commentCreate(Long boardId, String email, String content) {
+
+        Member member = memberQueryRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new IllegalArgumentException("게시물을 찾을 수 없습니다."));
+
+        Comment comment = Comment.commentCreate(content, member, board);
+
+        Comment save = commentRepository.save(comment);
+
+        return CommentResponseDto.commentResponseCreate(save);
+    }
+
+    @Override
+    public List<CommentResponseDto> findCommentsBoardById(Long boardId) {
+        List<Comment> comments = commentQueryRepository.findCommentsByBoardId(boardId);
+
+        return comments.stream().map(CommentResponseDto::commentResponseCreate)
+                .collect(toList());
+    }
+
+    @Override
+    @Transactional
+    public CommentResponseDto updateComment(Long boardId, String updateContent) {
+        return CommentService.super.updateComment(boardId, updateContent);
+    }
+}

--- a/src/main/java/com/example/yun/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/yun/service/impl/MemberServiceImpl.java
@@ -1,0 +1,45 @@
+package com.example.yun.service.impl;
+
+import com.example.yun.domain.member.Member;
+import com.example.yun.repository.member.MemberRepository;
+import com.example.yun.repository.querydsl.MemberQueryRepository;
+import com.example.yun.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final MemberQueryRepository memberQueryRepository;
+
+    @Override
+    @Transactional
+    public Member memberCreate(String email, String pwd) {
+        Member member = Member.create(email, pwd);
+
+        if(memberQueryRepository.duplicatedEmailCheck(email)) {
+            throw new IllegalStateException("중복된 회원 입니다.");
+        }
+
+        return memberRepository.save(member);
+    }
+
+    @Override
+    public String login(String email, String pwd) {
+        return MemberService.super.login(email, pwd);
+    }
+
+    @Override
+    public String logout(String email) {
+        return MemberService.super.logout(email);
+    }
+
+    @Override
+    public Member findMember(String email) {
+        return memberQueryRepository.findMemberByEmail(email);
+    }
+}

--- a/src/main/java/com/example/yun/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/yun/service/impl/MemberServiceImpl.java
@@ -1,20 +1,30 @@
 package com.example.yun.service.impl;
 
 import com.example.yun.domain.member.Member;
+import com.example.yun.jwt.JwtProvider;
 import com.example.yun.repository.member.MemberRepository;
 import com.example.yun.repository.querydsl.MemberQueryRepository;
 import com.example.yun.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
+import static com.example.yun.util.member.LoginCheckUtil.emailCheck;
+import static com.example.yun.util.member.LoginCheckUtil.passwordCheck;
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final MemberQueryRepository memberQueryRepository;
+    private final JwtProvider jwtProvider;
 
     @Override
     @Transactional
@@ -29,17 +39,34 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public String login(String email, String pwd) {
-        return MemberService.super.login(email, pwd);
+    public String login(String email, String pwd) throws JsonProcessingException {
+        Member member = Member.create(email, pwd);
+
+        Member findMember = memberQueryRepository.findMemberByEmail(email);
+
+        // 검증
+        if(emailCheck(member, findMember) && passwordCheck(member, findMember)) {
+            String token = jwtProvider.createToken(member.getEmail());
+            log.info("[token] = {}", token);
+
+            return token;
+        } else {
+            return null;
+        }
     }
 
     @Override
-    public String logout(String email) {
-        return MemberService.super.logout(email);
+    public String logout(String email, String jwt) {
+        return MemberService.super.logout(email, jwt);
     }
 
     @Override
-    public Member findMember(String email) {
-        return memberQueryRepository.findMemberByEmail(email);
+    public Member findMember(Long id) {
+        return getMember(id);
+    }
+
+    private Member getMember(Long id) {
+        return memberRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
     }
 }

--- a/src/main/java/com/example/yun/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/example/yun/service/impl/MemberServiceImpl.java
@@ -53,7 +53,7 @@ public class MemberServiceImpl implements MemberService {
 
             return token;
         } else {
-            return null;
+            throw new IllegalArgumentException("로그인을 할 수 없습니다.");
         }
     }
 

--- a/src/main/java/com/example/yun/util/DomainStringValidationUtil.java
+++ b/src/main/java/com/example/yun/util/DomainStringValidationUtil.java
@@ -1,0 +1,33 @@
+package com.example.yun.util;
+
+import com.example.yun.exception.StringValidationException;
+
+public class DomainStringValidationUtil {
+
+    public static String stringSettingTrim(String str) {
+        return str.trim();
+    }
+
+    public static boolean titleStringNullException(String str) {
+        if(str.equals("") || str.equals(" ") || titleLengthCheck(str)) {
+            throw new StringValidationException("문자열 형식이 틀립니다. 공백이거나 문자열 길이를 확인해주세요.");
+        }
+        return true;
+    }
+
+    public static boolean contentStringNullException(String str) {
+        if(str.equals("") || str.equals(" ") || contentLengthCheck(str)) {
+            throw new StringValidationException("문자열 형식이 틀립니다. 공백이거나 문자열 길이를 확인해주세요.");
+        }
+
+        return true;
+    }
+
+    private static boolean contentLengthCheck(String str) {
+        return str.length() > 1000;
+    }
+
+    private static boolean titleLengthCheck(String str) {
+        return str.length() > 15;
+    }
+}

--- a/src/main/java/com/example/yun/util/board/BoardValidationUtil.java
+++ b/src/main/java/com/example/yun/util/board/BoardValidationUtil.java
@@ -1,8 +1,8 @@
-package com.example.yun.util;
+package com.example.yun.util.board;
 
 import com.example.yun.exception.StringValidationException;
 
-public class DomainStringValidationUtil {
+public class BoardValidationUtil {
 
     public static String stringSettingTrim(String str) {
         return str.trim();

--- a/src/main/java/com/example/yun/util/jwt/JwtUtil.java
+++ b/src/main/java/com/example/yun/util/jwt/JwtUtil.java
@@ -1,24 +1,33 @@
 package com.example.yun.util.jwt;
 
+import com.example.yun.domain.member.Member;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+
+import javax.naming.AuthenticationException;
 
 @Slf4j
 public class JwtUtil {
 
+    private static final String key = "applicationKey";
+
     /**
      * 토큰 유효성, 만료 체크
-     * @param key 토큰 키
      * @param jwt 토큰
      * @return 유효성 통과 true, 실패 false
      */
-    public static boolean tokenExpiredCheck(String key, String jwt) {
+    public static boolean tokenExpiredCheck(String jwt) throws AuthenticationException {
         String token = getFormatToken(jwt);
 
+        if(token == null || token.equals(""))
+            throw new AuthenticationException("jwt is null!!");
+
         try {
-            Claims claims = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody();
+            Claims claims = Jwts.parser().setSigningKey(key.getBytes()).parseClaimsJws(token).getBody();
             log.info("[expireTime] = {}", claims.getExpiration());
             log.info("[subject] = {}", claims.getSubject());
         } catch (JwtException | NullPointerException e) {
@@ -27,6 +36,12 @@ public class JwtUtil {
         }
 
         return true;
+    }
+
+    public static String tokenPayloadExtract(String jwt) {
+        String token = getFormatToken(jwt);
+
+        return Jwts.parser().setSigningKey(key.getBytes()).parseClaimsJws(token).getBody().getSubject();
     }
 
     public static String getFormatToken(String jwt) {

--- a/src/main/java/com/example/yun/util/jwt/JwtUtil.java
+++ b/src/main/java/com/example/yun/util/jwt/JwtUtil.java
@@ -2,11 +2,18 @@ package com.example.yun.util.jwt;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
 @Slf4j
 public class JwtUtil {
 
     public static String getFormatToken(String jwt) {
         // bearer
         return jwt.split(" ")[1];
+    }
+
+    public static String getSigningKey(String key) {
+        return Base64.getEncoder().encodeToString(key.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/src/main/java/com/example/yun/util/jwt/JwtUtil.java
+++ b/src/main/java/com/example/yun/util/jwt/JwtUtil.java
@@ -1,0 +1,36 @@
+package com.example.yun.util.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JwtUtil {
+
+    /**
+     * 토큰 유효성, 만료 체크
+     * @param key 토큰 키
+     * @param jwt 토큰
+     * @return 유효성 통과 true, 실패 false
+     */
+    public static boolean tokenExpiredCheck(String key, String jwt) {
+        String token = getFormatToken(jwt);
+
+        try {
+            Claims claims = Jwts.parser().setSigningKey(key).parseClaimsJws(token).getBody();
+            log.info("[expireTime] = {}", claims.getExpiration());
+            log.info("[subject] = {}", claims.getSubject());
+        } catch (JwtException | NullPointerException e) {
+            log.error("token error!!");
+            return false;
+        }
+
+        return true;
+    }
+
+    public static String getFormatToken(String jwt) {
+        // bearer
+        return jwt.split(" ")[1];
+    }
+}

--- a/src/main/java/com/example/yun/util/jwt/JwtUtil.java
+++ b/src/main/java/com/example/yun/util/jwt/JwtUtil.java
@@ -1,48 +1,9 @@
 package com.example.yun.util.jwt;
 
-import com.example.yun.domain.member.Member;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.JwtException;
-import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-
-import javax.naming.AuthenticationException;
 
 @Slf4j
 public class JwtUtil {
-
-    private static final String key = "applicationKey";
-
-    /**
-     * 토큰 유효성, 만료 체크
-     * @param jwt 토큰
-     * @return 유효성 통과 true, 실패 false
-     */
-    public static boolean tokenExpiredCheck(String jwt) throws AuthenticationException {
-        String token = getFormatToken(jwt);
-
-        if(token == null || token.equals(""))
-            throw new AuthenticationException("jwt is null!!");
-
-        try {
-            Claims claims = Jwts.parser().setSigningKey(key.getBytes()).parseClaimsJws(token).getBody();
-            log.info("[expireTime] = {}", claims.getExpiration());
-            log.info("[subject] = {}", claims.getSubject());
-        } catch (JwtException | NullPointerException e) {
-            log.error("token error!!");
-            return false;
-        }
-
-        return true;
-    }
-
-    public static String tokenPayloadExtract(String jwt) {
-        String token = getFormatToken(jwt);
-
-        return Jwts.parser().setSigningKey(key.getBytes()).parseClaimsJws(token).getBody().getSubject();
-    }
 
     public static String getFormatToken(String jwt) {
         // bearer

--- a/src/main/java/com/example/yun/util/member/LoginCheckUtil.java
+++ b/src/main/java/com/example/yun/util/member/LoginCheckUtil.java
@@ -1,0 +1,14 @@
+package com.example.yun.util.member;
+
+import com.example.yun.domain.member.Member;
+
+public class LoginCheckUtil {
+
+    public static boolean passwordCheck(Member member, Member findMember) {
+        return findMember.getPassword().equals(member.getPassword());
+    }
+
+    public static boolean emailCheck(Member member, Member findMember) {
+        return findMember.getEmail().equals(member.getEmail());
+    }
+}

--- a/src/main/java/com/example/yun/util/member/MemberValidationUtil.java
+++ b/src/main/java/com/example/yun/util/member/MemberValidationUtil.java
@@ -1,0 +1,36 @@
+package com.example.yun.util.member;
+
+import com.example.yun.exception.StringValidationException;
+
+public class MemberValidationUtil {
+
+    public static String stringSettingTrim(String str) {
+        return str.trim();
+    }
+
+    public static boolean emailValidationCheck(String email) {
+        if(email.equals("") || email.equals(" ") || !emailValidation(email)) {
+            throw new StringValidationException("이메일 형식이 옳지 않습니다.");
+        }
+
+        return true;
+    }
+
+    public static boolean pwdValidationCheck(String password) {
+        if(password.equals("") || password.equals(" ") || !pwdValidation(password)) {
+            throw new StringValidationException("비밀번호는 8 ~ 15자 사이로 지정해주세요.");
+        }
+
+        return true;
+    }
+
+    private static boolean pwdValidation(String password) {
+        // 비밀번호는 8 ~ 15자 사이 특수문자 하나 이상 대문자 하나 이상.
+        return password.matches("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$");
+    }
+
+    private static boolean emailValidation(String email) {
+        // RFC 5322 방식.
+        return email.matches("^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$");
+    }
+}

--- a/src/main/java/com/example/yun/util/member/MemberValidationUtil.java
+++ b/src/main/java/com/example/yun/util/member/MemberValidationUtil.java
@@ -24,6 +24,8 @@ public class MemberValidationUtil {
         return true;
     }
 
+
+
     private static boolean pwdValidation(String password) {
         // 비밀번호는 8 ~ 15자 사이 특수문자 하나 이상 대문자 하나 이상.
         return password.matches("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,15}$");

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -21,3 +21,16 @@ logging:
 #    org.hibernate.type: trace
 server:
   port: 5000
+
+origin:
+  address: http://localhost:8000
+
+jwt:
+  key: applicationKey
+  blackList: blackList
+  expireTime:
+    access: 3600000
+    refresh: 1296000000
+
+valid:
+  password: ^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -29,3 +29,6 @@ jwt:
   expireTime:
     access: 3600000
     refresh: 1296000000
+
+valid:
+  password: ^[a-zA-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[a-zA-Z0-9.-]+$;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,3 +19,6 @@ logging:
   level: #띄어쓰기 없음
     org.hibernate.SQL: debug
 #    org.hibernate.type: trace
+
+origin:
+  address: http://localhost:8000

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -22,3 +22,10 @@ logging:
 
 origin:
   address: http://localhost:8000
+
+jwt:
+  key: applicationKey
+  blackList: blackList
+  expireTime:
+    access: 3600000
+    refresh: 1296000000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: dev
+    active: local
 #spring:
 #  datasource:
 #    url: jdbc:mysql://localhost:3333/myDB?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: dev
 #spring:
 #  datasource:
 #    url: jdbc:mysql://localhost:3333/myDB?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true

--- a/src/test/java/com/example/yun/controller/BoardControllerTest.java
+++ b/src/test/java/com/example/yun/controller/BoardControllerTest.java
@@ -42,9 +42,11 @@ class BoardControllerTest {
     private String token = "bearer ";
     private final String headerName = "Authorization";
 
+    private String email;
+
     @BeforeEach
     void memberLoginInit() {
-        String email = "qwer1234@naver.com";
+        email = "qwer1234@naver.com";
         String pwd = "qwer1234@A";
 
         memberService.memberCreate(email, pwd);
@@ -66,7 +68,7 @@ class BoardControllerTest {
             // given
             String title = "안녕";
             String content = "안녕하세요";
-            BoardRequestDto boardRequestDto = new BoardRequestDto(title, content);
+            BoardRequestDto boardRequestDto = BoardRequestDto.boardRequestCreate(title, content, email);
 
             String s = objectMapper.writeValueAsString(boardRequestDto);
 
@@ -91,10 +93,10 @@ class BoardControllerTest {
 
             @BeforeEach
             void init() {
-                BoardRequestDto boardRequestDto = new BoardRequestDto("안녕", "안녕하세요");
+                BoardRequestDto boardRequestDto = BoardRequestDto.boardRequestCreate("안녕", "안녕하세요", email);
 
                 boardResponseDto = boardService.boardCreate(boardRequestDto.getTitle(),
-                        boardRequestDto.getContent());
+                        boardRequestDto.getContent(), boardRequestDto.getEmail());
             }
 
             @Test
@@ -161,10 +163,10 @@ class BoardControllerTest {
 
             @BeforeEach
             void init() {
-                BoardRequestDto boardRequestDto = new BoardRequestDto("안녕", "안녕하세요");
+                BoardRequestDto boardRequestDto = BoardRequestDto.boardRequestCreate("안녕", "안녕하세요", email);
 
                 boardResponseDto = boardService.boardCreate(boardRequestDto.getTitle(),
-                        boardRequestDto.getContent());
+                        boardRequestDto.getContent(), boardRequestDto.getEmail());
             }
 
             @Test
@@ -225,10 +227,10 @@ class BoardControllerTest {
 
             @BeforeEach
             void init() {
-                BoardRequestDto boardRequestDto = new BoardRequestDto("안녕", "안녕하세요");
+                BoardRequestDto boardRequestDto = BoardRequestDto.boardRequestCreate("안녕", "안녕하세요", email);
 
                 boardResponseDto = boardService.boardCreate(boardRequestDto.getTitle(),
-                        boardRequestDto.getContent());
+                        boardRequestDto.getContent(), boardRequestDto.getEmail());
             }
 
             @Test
@@ -264,7 +266,7 @@ class BoardControllerTest {
             @DisplayName("공백 or 빈칸")
             void validationEmptyFailed() throws Exception {
                 // given
-                BoardRequestDto boardRequestDto = new BoardRequestDto("", " ");
+                BoardRequestDto boardRequestDto = BoardRequestDto.boardRequestCreate("", "", email);
                 String s = objectMapper.writeValueAsString(boardRequestDto);
 
                 // when
@@ -302,7 +304,7 @@ class BoardControllerTest {
                 // given
                 String overTitle = "aldfjghfjdkshgjghfdkghkjfdhgkfdgfd";
                 String content = "ㅎㅇ";
-                BoardRequestDto boardRequestDto = new BoardRequestDto(overTitle, content);
+                BoardRequestDto boardRequestDto = BoardRequestDto.boardRequestCreate(overTitle, content, email);
                 String s = objectMapper.writeValueAsString(boardRequestDto);
 
                 // when

--- a/src/test/java/com/example/yun/controller/BoardControllerTest.java
+++ b/src/test/java/com/example/yun/controller/BoardControllerTest.java
@@ -5,7 +5,10 @@ import com.example.yun.dto.BoardResponseDto;
 import com.example.yun.dto.update.BoardContentUpdateDto;
 import com.example.yun.dto.update.BoardTitleUpdateDto;
 import com.example.yun.repository.BoardRepository;
+import com.example.yun.repository.member.MemberRepository;
 import com.example.yun.service.BoardService;
+import com.example.yun.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,8 +34,28 @@ class BoardControllerTest {
     @Autowired
     private BoardRepository boardRepository;
     @Autowired
+    private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
     private ObjectMapper objectMapper;
 
+    private String token = "bearer ";
+    private final String headerName = "Authorization";
+
+    @BeforeEach
+    void memberLoginInit() throws JsonProcessingException {
+        String email = "qwer1234@naver.com";
+        String pwd = "qwer1234@A";
+
+        memberService.memberCreate(email, pwd);
+        token += memberService.login(email, pwd);
+    }
+
+    @AfterEach
+    void memberDbInit() {
+        memberRepository.deleteAll();
+    }
 
     @Nested
     @DisplayName("성공")
@@ -50,6 +73,7 @@ class BoardControllerTest {
 
             // when
             ResultActions resultActions = mockMvc.perform(post("/api/boards")
+                    .header(headerName, token)
                     .content(s)
                     .contentType(MediaType.APPLICATION_JSON)
                     .accept(MediaType.APPLICATION_JSON));
@@ -81,7 +105,8 @@ class BoardControllerTest {
                 int size = 1;
 
                 // when
-                ResultActions resultActions = mockMvc.perform(get("/api/boards"));
+                ResultActions resultActions = mockMvc.perform(get("/api/boards")
+                        .header(headerName, token));
 
                 // then
                 resultActions.andExpect(status().isOk())
@@ -97,7 +122,8 @@ class BoardControllerTest {
                 Long id = boardResponseDto.getId();
 
                 // when
-                ResultActions resultActions = mockMvc.perform(get("/api/boards/{boardId}", id));
+                ResultActions resultActions = mockMvc.perform(get("/api/boards/{boardId}", id)
+                        .header(headerName, token));
 
                 // then
                 resultActions.andExpect(status().isOk())
@@ -113,6 +139,7 @@ class BoardControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(get("/api/boards/keyword")
+                        .header(headerName, token)
                         .param("keyword", keyword));
 
                 // then
@@ -152,6 +179,7 @@ class BoardControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(patch("/api/boards/title")
+                        .header(headerName, token)
                         .content(s)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON));
@@ -173,6 +201,7 @@ class BoardControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(patch("/api/boards/content")
+                        .header(headerName, token)
                         .content(s)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON));
@@ -210,7 +239,8 @@ class BoardControllerTest {
                 Long id = boardResponseDto.getId();
 
                 // when
-                ResultActions resultActions = mockMvc.perform(delete("/api/boards/{boardId}", id));
+                ResultActions resultActions = mockMvc.perform(delete("/api/boards/{boardId}", id)
+                        .header(headerName, token));
 
                 // then
                 resultActions.andExpect(status().isNoContent())
@@ -240,6 +270,7 @@ class BoardControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(post("/api/boards")
+                        .header(headerName, token)
                         .content(s)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON));
@@ -257,6 +288,7 @@ class BoardControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(patch("/api/boards/title")
+                        .header(headerName, token)
                         .content(s)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON));
@@ -276,6 +308,7 @@ class BoardControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(post("/api/boards")
+                        .header(headerName, token)
                         .content(s)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON));
@@ -292,6 +325,7 @@ class BoardControllerTest {
 
                 // when
                 ResultActions resultActions = mockMvc.perform(get("/api/boards/keyword")
+                        .header(headerName, token)
                         .param("keyword", keyword));
 
                 // then

--- a/src/test/java/com/example/yun/controller/BoardControllerTest.java
+++ b/src/test/java/com/example/yun/controller/BoardControllerTest.java
@@ -8,7 +8,6 @@ import com.example.yun.repository.BoardRepository;
 import com.example.yun.repository.member.MemberRepository;
 import com.example.yun.service.BoardService;
 import com.example.yun.service.MemberService;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +43,7 @@ class BoardControllerTest {
     private final String headerName = "Authorization";
 
     @BeforeEach
-    void memberLoginInit() throws JsonProcessingException {
+    void memberLoginInit() {
         String email = "qwer1234@naver.com";
         String pwd = "qwer1234@A";
 

--- a/src/test/java/com/example/yun/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/yun/controller/MemberControllerTest.java
@@ -1,0 +1,108 @@
+package com.example.yun.controller;
+
+import com.example.yun.dto.member.MemberRequestDto;
+import com.example.yun.dto.member.login.LoginRequestDto;
+import com.example.yun.service.MemberService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import javax.servlet.http.HttpServletRequest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private MemberService memberService;
+
+    @Test
+    @DisplayName("회원 가입")
+    void memberCreateApiTest() throws Exception {
+        // given
+        String email = "qwer1234@naver.com";
+        String pwd = "qwer1234@A";
+        MemberRequestDto memberRequestDto = MemberRequestDto.create(email, pwd);
+
+        String s = objectMapper.writeValueAsString(memberRequestDto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post("/api/member/create")
+                .content(s)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions.andExpect(status().isCreated())
+                .andExpect(jsonPath("$.email").value(email))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원 찾기")
+    void findMemberApiTest() throws Exception {
+        // given
+        String email = "qwer1234@naver.com";
+        String pwd = "qwer1234@A";
+
+        memberCreateInit(email, pwd);
+        String token = memberService.login(email, pwd);
+
+        String requestToken = "bearer " + token;
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/member")
+                .header("Authorization", requestToken));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("로그인")
+    void loginApiTest() throws Exception {
+        // given
+        String email = "qwer1234@naver.com";
+        String pwd = "qwer1234@A";
+
+        memberCreateInit(email, pwd);
+
+        LoginRequestDto loginRequestDto = LoginRequestDto.create(email, pwd);
+
+        String s = objectMapper.writeValueAsString(loginRequestDto);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(get("/api/member/login")
+                .content(s)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        resultActions.andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    void memberCreateInit(String email, String pwd) {
+        memberService.memberCreate(email, pwd);
+    }
+}

--- a/src/test/java/com/example/yun/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/yun/controller/MemberControllerTest.java
@@ -2,8 +2,10 @@ package com.example.yun.controller;
 
 import com.example.yun.dto.member.MemberRequestDto;
 import com.example.yun.dto.member.login.LoginRequestDto;
+import com.example.yun.repository.member.MemberRepository;
 import com.example.yun.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +31,13 @@ class MemberControllerTest {
     private ObjectMapper objectMapper;
     @Autowired
     private MemberService memberService;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @AfterEach
+    void dbInit() {
+        memberRepository.deleteAll();
+    }
 
     @Test
     @DisplayName("회원 가입")

--- a/src/test/java/com/example/yun/controller/MemberControllerTest.java
+++ b/src/test/java/com/example/yun/controller/MemberControllerTest.java
@@ -4,19 +4,14 @@ import com.example.yun.dto.member.MemberRequestDto;
 import com.example.yun.dto.member.login.LoginRequestDto;
 import com.example.yun.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-
-import javax.servlet.http.HttpServletRequest;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/src/test/java/com/example/yun/domain/board/BoardTest.java
+++ b/src/test/java/com/example/yun/domain/board/BoardTest.java
@@ -1,0 +1,54 @@
+package com.example.yun.domain.board;
+
+import com.example.yun.exception.StringValidationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BoardTest {
+
+    @Nested
+    @DisplayName("제목")
+    class Email {
+
+        @DisplayName("제목이 공백이거나 길이가 15자를 넘어가는 경우")
+        @ParameterizedTest
+        @ValueSource(ints = {0, 20})
+        void titleLengthOver(int num) {
+            // given
+            String title = " ".repeat(num);
+            String content = "ㅎㅇ";
+
+            // when
+
+            // then
+            assertThatThrownBy(() -> Board.create(title, content))
+                    .isInstanceOf(StringValidationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("내용")
+    class Content {
+
+        @DisplayName("내용이 공백이거나 길이가 1000자를 넘어가는 경우")
+        @ParameterizedTest
+        @ValueSource(ints = {0, 1100})
+        void contentLengthOver(int num) {
+            // given
+            String title = "ㅎㅇ";
+            String content = " ".repeat(num);
+
+            // when
+
+            // then
+            assertThatThrownBy(() -> Board.create(title, content))
+                    .isInstanceOf(StringValidationException.class);
+        }
+
+    }
+
+}

--- a/src/test/java/com/example/yun/domain/board/BoardTest.java
+++ b/src/test/java/com/example/yun/domain/board/BoardTest.java
@@ -25,7 +25,7 @@ class BoardTest {
             // when
 
             // then
-            assertThatThrownBy(() -> Board.create(title, content))
+            assertThatThrownBy(() -> Board.create(title, content, null))
                     .isInstanceOf(StringValidationException.class);
         }
     }
@@ -45,7 +45,7 @@ class BoardTest {
             // when
 
             // then
-            assertThatThrownBy(() -> Board.create(title, content))
+            assertThatThrownBy(() -> Board.create(title, content,null))
                     .isInstanceOf(StringValidationException.class);
         }
 

--- a/src/test/java/com/example/yun/domain/member/MemberTest.java
+++ b/src/test/java/com/example/yun/domain/member/MemberTest.java
@@ -60,6 +60,21 @@ class MemberTest {
                 assertThatThrownBy(() -> Member.create(email, pwd))
                         .isInstanceOf(StringValidationException.class);
             }
+
+            @Test
+            @DisplayName("@가 2개 이상일 경우")
+            void emailMissMatchCheck() {
+                // given
+                String email = "qwer1234@@naver.com";
+                String pwd = "qwer1234@A";
+
+                // when
+
+                // then
+                assertThatThrownBy(() -> Member.create(email, pwd))
+                        .isInstanceOf(StringValidationException.class);
+
+            }
         }
     }
 

--- a/src/test/java/com/example/yun/domain/member/MemberTest.java
+++ b/src/test/java/com/example/yun/domain/member/MemberTest.java
@@ -1,0 +1,132 @@
+package com.example.yun.domain.member;
+
+import com.example.yun.exception.StringValidationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MemberTest {
+
+    @Nested
+    @DisplayName("이메일")
+    class Email {
+
+        @Nested
+        @DisplayName("유효성")
+        class Validation {
+
+            @Test
+            @DisplayName("정상적인 이메일")
+            void passwordCheck() {
+                // given
+                String email = "qwer1234@naver.com";
+                String pwd = "qwer1234@A";
+
+                // when
+                Member member = Member.create(email, pwd);
+
+                // then
+                assertThat(member.getEmail()).isEqualTo(email);
+                assertThat(member.getPassword()).isEqualTo(pwd);
+            }
+
+            @Test
+            @DisplayName("@가 빠진 경우")
+            void emailCheck() {
+                // given
+                String email = "qwer1234naver.com";
+                String pwd = "qwer1234@A";
+
+                // when
+
+                // then
+                assertThatThrownBy(() -> Member.create(email, pwd))
+                        .isInstanceOf(StringValidationException.class);
+            }
+
+            @Test
+            @DisplayName("공백이 있는 경우")
+            void emailSpaceCheck() {
+                // given
+                String email = "qwer123 @naver.com";
+                String pwd = "qwer1234@A";
+
+                // when
+
+                // then
+                assertThatThrownBy(() -> Member.create(email, pwd))
+                        .isInstanceOf(StringValidationException.class);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("비밀번호")
+    class Password {
+
+        @Nested
+        @DisplayName("유효성")
+        class Validation {
+
+            @Test
+            @DisplayName("정상적인 비밀번호")
+            void passwordCheck() {
+                // given
+                String email = "qwer1234@naver.com";
+                String pwd = "qwer1234@A";
+
+                // when
+                Member member = Member.create(email, pwd);
+
+                // then
+                assertThat(member.getEmail()).isEqualTo(email);
+                assertThat(member.getPassword()).isEqualTo(pwd);
+            }
+
+            @Test
+            @DisplayName("8 ~ 15자 사이 체크")
+            void passwordLengthCheck() {
+                // given
+                String email = "qwer1234@naver.com";
+                String pwd = "dd12@";
+
+                // when
+
+                // then
+                assertThatThrownBy(() -> Member.create(email, pwd))
+                        .isInstanceOf(StringValidationException.class);
+            }
+
+            @Test
+            @DisplayName("비밀번호는 특수 문자 1개 이상 대문자 1개이상 숫자 1개 이상 포함하고 소문자로 이루어져야 한다.")
+            void emailValidationCheck() {
+                // given
+                String email = "qwer1234@naver.com";
+                String pwd = "qwerqwerqwer";
+
+                // when
+
+                // then
+                assertThatThrownBy(() -> Member.create(email, pwd))
+                        .isInstanceOf(StringValidationException.class);
+            }
+
+            @Test
+            @DisplayName("공백 체크")
+            void passwordSpaceCheck() {
+                // given
+                String email = "qwer1234@naver.com";
+                String pwd = "qwerqwerq er";
+
+                // when
+
+                // then
+                assertThatThrownBy(() -> Member.create(email, pwd))
+                        .isInstanceOf(StringValidationException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/com/example/yun/jwt/JwtProviderTest.java
+++ b/src/test/java/com/example/yun/jwt/JwtProviderTest.java
@@ -1,9 +1,12 @@
 package com.example.yun.jwt;
 
 import com.example.yun.domain.member.Member;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 

--- a/src/test/java/com/example/yun/jwt/JwtProviderTest.java
+++ b/src/test/java/com/example/yun/jwt/JwtProviderTest.java
@@ -1,13 +1,41 @@
 package com.example.yun.jwt;
 
+import com.example.yun.domain.member.Member;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JwtProviderTest {
 
     @Test
-    @DisplayName("토큰 유효성 예외 체크")
-    void tokenValidationCheck() {
+    @DisplayName("토큰 만료 테스트 -> 만료된 토큰")
+    void tokenExpireTestFalse() {
+        // given
+        JwtProvider jwtProvider = new JwtProvider("applicationKey", 0L);
 
+        // when
+        String token = jwtProvider.createToken(Member.create("qwer1234@naver.com", "qwer1234@A"));
+
+        String accessToken = "bearer " + token;
+
+        // then
+        assertFalse(jwtProvider.tokenExpiredCheck(accessToken));
+    }
+
+    @Test
+    @DisplayName("토큰 만료 테스트 -> 만료되지 않은 토큰")
+    void tokenExpireTestTrue() {
+        // given
+        JwtProvider jwtProvider = new JwtProvider("applicationKey", 100000L);
+
+        // when
+        String token = jwtProvider.createToken(Member.create("qwer1234@naver.com", "qwer1234@A"));
+
+        String accessToken = "bearer " + token;
+
+        // then
+        assertTrue(jwtProvider.tokenExpiredCheck(accessToken));
     }
 }

--- a/src/test/java/com/example/yun/jwt/JwtProviderTest.java
+++ b/src/test/java/com/example/yun/jwt/JwtProviderTest.java
@@ -1,0 +1,13 @@
+package com.example.yun.jwt;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtProviderTest {
+
+    @Test
+    @DisplayName("토큰 유효성 예외 체크")
+    void tokenValidationCheck() {
+
+    }
+}

--- a/src/test/java/com/example/yun/repository/querydsl/impl/BoardQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/example/yun/repository/querydsl/impl/BoardQueryDslRepositoryImplTest.java
@@ -1,6 +1,8 @@
 package com.example.yun.repository.querydsl.impl;
 
 import com.example.yun.domain.board.Board;
+import com.example.yun.domain.board.Content;
+import com.example.yun.domain.board.Title;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -59,7 +61,7 @@ class BoardQueryDslRepositoryImplTest {
 
             // when
             List<Board> boards = jpaQueryFactory.selectFrom(board)
-                    .where(board.title.contains(keyword))
+                    .where(board.title.title.contains(keyword))
                     .orderBy(board.createTime.desc())
                     .limit(100L)
                     .fetch();
@@ -70,7 +72,7 @@ class BoardQueryDslRepositoryImplTest {
 
         void boardListInit() {
             for(int i = 0; i < 101; i++) {
-                Board board = new Board("안녕", "안녕하세요");
+                Board board = new Board(Title.titleCreate("안녕"), Content.contentCreate("안녕하세요"));
                 em.persist(board);
             }
         }

--- a/src/test/java/com/example/yun/repository/querydsl/impl/BoardQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/example/yun/repository/querydsl/impl/BoardQueryDslRepositoryImplTest.java
@@ -72,7 +72,7 @@ class BoardQueryDslRepositoryImplTest {
 
         void boardListInit() {
             for(int i = 0; i < 101; i++) {
-                Board board = Board.create("안녕", "안녕하세요");
+                Board board = Board.create("안녕", "안녕하세요", null);
                 em.persist(board);
             }
         }

--- a/src/test/java/com/example/yun/repository/querydsl/impl/BoardQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/example/yun/repository/querydsl/impl/BoardQueryDslRepositoryImplTest.java
@@ -72,7 +72,7 @@ class BoardQueryDslRepositoryImplTest {
 
         void boardListInit() {
             for(int i = 0; i < 101; i++) {
-                Board board = new Board(Title.titleCreate("안녕"), Content.contentCreate("안녕하세요"));
+                Board board = Board.create("안녕", "안녕하세요");
                 em.persist(board);
             }
         }

--- a/src/test/java/com/example/yun/repository/querydsl/impl/CommentQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/example/yun/repository/querydsl/impl/CommentQueryDslRepositoryImplTest.java
@@ -1,0 +1,68 @@
+package com.example.yun.repository.querydsl.impl;
+
+import com.example.yun.domain.Comment.Comment;
+import com.example.yun.domain.board.Board;
+import com.example.yun.domain.member.Member;
+import com.example.yun.repository.BoardRepository;
+import com.example.yun.repository.comment.CommentRepository;
+import com.example.yun.repository.member.MemberRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.example.yun.domain.Comment.QComment.comment;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class CommentQueryDslRepositoryImplTest {
+
+    @Autowired
+    private EntityManager em;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private BoardRepository boardRepository;
+    @Autowired
+    private CommentRepository commentRepository;
+
+    private JPAQueryFactory jpaQueryFactory;
+    private Board boardSave;
+    private Member memberSave;
+
+    @BeforeEach
+    void init() {
+        jpaQueryFactory = new JPAQueryFactory(em);
+
+        Member member = Member.create("qwer1234@naver.com", "qwer1234@A");
+        memberSave = memberRepository.save(member);
+
+        Board board = Board.create("ㅎㅇ", "ㅎㅇ", memberSave);
+        boardSave = boardRepository.save(board);
+
+    }
+
+    @Test
+    @DisplayName("게시물 id로 조회하여 댓글 리스트 출력")
+    void boardIdFindOutputCommentList() {
+        // given
+        Comment c = Comment.commentCreate("ㅎㅇ", memberSave, boardSave);
+        Comment commentSave = commentRepository.save(c);
+
+        // when
+        List<Comment> comments = jpaQueryFactory.selectFrom(comment)
+                .where(comment.board.id.eq(boardSave.getId()))
+                .fetch();
+
+        // then
+        assertThat(comments.size()).isEqualTo(1);
+        assertThat(comments.get(0)).isEqualTo(commentSave);
+    }
+}

--- a/src/test/java/com/example/yun/repository/querydsl/impl/MemberQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/example/yun/repository/querydsl/impl/MemberQueryDslRepositoryImplTest.java
@@ -1,0 +1,53 @@
+package com.example.yun.repository.querydsl.impl;
+
+import com.example.yun.domain.member.Member;
+import com.example.yun.domain.member.QMember;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import javax.persistence.EntityManager;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+class MemberQueryDslRepositoryImplTest {
+
+    @Autowired
+    private EntityManager em;
+
+    private JPAQueryFactory jpaQueryFactory;
+
+    @BeforeEach
+    void init() {
+        jpaQueryFactory = new JPAQueryFactory(em);
+    }
+
+    @Nested
+    @DisplayName("중복 검사")
+    class Duplication {
+
+        @Test
+        @DisplayName("이메일 중복 체크 true 이면 중복")
+        void emailDuplicationCheck () {
+            // given
+            String email = "qwer1234@naver.com";
+            String pwd = "qwer1234@A";
+            Member member = Member.create(email, pwd);
+
+            em.persist(member);
+
+            // when
+            boolean emailCheck = jpaQueryFactory.selectFrom(QMember.member)
+                    .where(QMember.member.email.email.eq(email))
+                    .fetchFirst() != null;
+
+            // then
+            assertTrue(emailCheck);
+        }
+    }
+}

--- a/src/test/java/com/example/yun/repository/querydsl/impl/MemberQueryDslRepositoryImplTest.java
+++ b/src/test/java/com/example/yun/repository/querydsl/impl/MemberQueryDslRepositoryImplTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 import javax.persistence.EntityManager;
@@ -15,6 +16,7 @@ import javax.persistence.EntityManager;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MemberQueryDslRepositoryImplTest {
 
     @Autowired

--- a/src/test/java/com/example/yun/service/impl/BoardServiceImplTest.java
+++ b/src/test/java/com/example/yun/service/impl/BoardServiceImplTest.java
@@ -1,6 +1,8 @@
 package com.example.yun.service.impl;
 
 import com.example.yun.domain.board.Board;
+import com.example.yun.domain.board.Content;
+import com.example.yun.domain.board.Title;
 import com.example.yun.dto.BoardRequestDto;
 import com.example.yun.dto.BoardResponseDto;
 import com.example.yun.dto.update.BoardContentUpdateDto;
@@ -20,6 +22,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.example.yun.domain.board.Content.*;
+import static com.example.yun.domain.board.Title.*;
 import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -44,9 +48,7 @@ class BoardServiceImplTest {
 
         @BeforeEach
         void init() {
-            Long id = 1L;
-            board = new Board("안녕하세요", "안녕");
-            board.setId(id);
+            board = new Board(titleCreate("안녕하세요"), contentCreate("안녕"));
         }
 
         @Test
@@ -190,9 +192,7 @@ class BoardServiceImplTest {
 
         @BeforeEach
         void init() {
-            Long id = 1L;
-            board = new Board("안녕하세요", "안녕");
-            board.setId(id);
+            board = new Board(titleCreate("안녕하세요"), contentCreate("안녕"));
         }
 
         @Nested

--- a/src/test/java/com/example/yun/service/impl/BoardServiceImplTest.java
+++ b/src/test/java/com/example/yun/service/impl/BoardServiceImplTest.java
@@ -1,15 +1,13 @@
 package com.example.yun.service.impl;
 
 import com.example.yun.domain.board.Board;
-import com.example.yun.domain.board.Content;
-import com.example.yun.domain.board.Title;
 import com.example.yun.dto.BoardRequestDto;
 import com.example.yun.dto.BoardResponseDto;
 import com.example.yun.dto.update.BoardContentUpdateDto;
 import com.example.yun.dto.update.BoardTitleUpdateDto;
+import com.example.yun.exception.BoardMessage;
 import com.example.yun.repository.BoardRepository;
 import com.example.yun.repository.querydsl.BoardQueryRepository;
-import com.example.yun.exception.BoardMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -22,8 +20,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.example.yun.domain.board.Content.*;
-import static com.example.yun.domain.board.Title.*;
+import static com.example.yun.domain.board.Content.contentCreate;
+import static com.example.yun.domain.board.Title.titleCreate;
 import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/com/example/yun/service/impl/BoardServiceImplTest.java
+++ b/src/test/java/com/example/yun/service/impl/BoardServiceImplTest.java
@@ -1,6 +1,7 @@
 package com.example.yun.service.impl;
 
 import com.example.yun.domain.board.Board;
+import com.example.yun.domain.member.Member;
 import com.example.yun.dto.BoardRequestDto;
 import com.example.yun.dto.BoardResponseDto;
 import com.example.yun.dto.update.BoardContentUpdateDto;
@@ -8,6 +9,7 @@ import com.example.yun.dto.update.BoardTitleUpdateDto;
 import com.example.yun.exception.BoardMessage;
 import com.example.yun.repository.BoardRepository;
 import com.example.yun.repository.querydsl.BoardQueryRepository;
+import com.example.yun.repository.querydsl.MemberQueryRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,8 +22,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.example.yun.domain.board.Content.contentCreate;
-import static com.example.yun.domain.board.Title.titleCreate;
 import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -37,16 +37,20 @@ class BoardServiceImplTest {
     private BoardRepository boardRepository;
     @Mock
     private BoardQueryRepository boardQueryRepository;
+    @Mock
+    private MemberQueryRepository memberQueryRepository;
 
     @Nested
     @DisplayName("게시물 성공")
     class Success {
 
         private Board board;
+        private Member member;
 
         @BeforeEach
         void init() {
-            board = Board.create("안녕하세요", "안녕");
+            member = Member.create("qwer1234@naver.com", "qwer1234@A");
+            board = Board.create("안녕하세요", "안녕", member);
         }
 
         @Test
@@ -55,12 +59,17 @@ class BoardServiceImplTest {
             // given
             String title = "안녕하세요";
             String content = "안녕";
-            BoardRequestDto boardRequestDto = new BoardRequestDto(title, content);
+            String email = "qwer1234@naver.com";
+            BoardRequestDto boardRequestDto = BoardRequestDto.boardRequestCreate(title, content, email);
 
+            given(memberQueryRepository.findMemberByEmail(email)).willReturn(of(member));
             given(boardRepository.save(any())).willReturn(board);
 
             // when
-            BoardResponseDto boardResponseDto = boardService.boardCreate(boardRequestDto.getTitle(), boardRequestDto.getContent());
+            BoardResponseDto boardResponseDto = boardService.boardCreate(
+                    boardRequestDto.getTitle(),
+                    boardRequestDto.getContent(),
+                    boardRequestDto.getEmail());
 
             // then
             assertThat(boardRequestDto.getTitle()).isEqualTo(boardResponseDto.getTitle());
@@ -185,13 +194,6 @@ class BoardServiceImplTest {
     @Nested
     @DisplayName("게시물 실패")
     class Failed {
-
-        private Board board;
-
-        @BeforeEach
-        void init() {
-            board = Board.create("안녕하세요", "안녕");
-        }
 
         @Nested
         @DisplayName("공통 에러 -> 존재하지 않는 id")

--- a/src/test/java/com/example/yun/service/impl/BoardServiceImplTest.java
+++ b/src/test/java/com/example/yun/service/impl/BoardServiceImplTest.java
@@ -46,7 +46,7 @@ class BoardServiceImplTest {
 
         @BeforeEach
         void init() {
-            board = new Board(titleCreate("안녕하세요"), contentCreate("안녕"));
+            board = Board.create("안녕하세요", "안녕");
         }
 
         @Test
@@ -190,7 +190,7 @@ class BoardServiceImplTest {
 
         @BeforeEach
         void init() {
-            board = new Board(titleCreate("안녕하세요"), contentCreate("안녕"));
+            board = Board.create("안녕하세요", "안녕");
         }
 
         @Nested

--- a/src/test/java/com/example/yun/service/impl/CommentServiceImplTest.java
+++ b/src/test/java/com/example/yun/service/impl/CommentServiceImplTest.java
@@ -1,0 +1,158 @@
+package com.example.yun.service.impl;
+
+import com.example.yun.domain.Comment.Comment;
+import com.example.yun.domain.board.Board;
+import com.example.yun.domain.member.Member;
+import com.example.yun.dto.comment.CommentResponseDto;
+import com.example.yun.exception.ExceptionControl;
+import com.example.yun.exception.NotFoundBoardException;
+import com.example.yun.exception.NotFoundMemberException;
+import com.example.yun.jwt.JwtObject;
+import com.example.yun.jwt.JwtProvider;
+import com.example.yun.repository.BoardRepository;
+import com.example.yun.repository.comment.CommentRepository;
+import com.example.yun.repository.member.MemberRepository;
+import com.example.yun.repository.querydsl.CommentQueryRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static com.example.yun.exception.ExceptionControl.*;
+import static java.util.Optional.of;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceImplTest {
+
+    @InjectMocks
+    private CommentServiceImpl commentService;
+    @Mock
+    private CommentRepository commentRepository;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private CommentQueryRepository commentQueryRepository;
+    @Mock
+    private BoardRepository boardRepository;
+    @Mock
+    private JwtProvider jwtProvider;
+
+    String email = "qwer1234@naver.com";
+    String pwd = "qwer1234@A";
+    Member member = Member.create(email, pwd);
+    Board board = Board.create("ㅎㅇ", "ㅎㅇ", member);
+    Comment comment = Comment.commentCreate("ㅎㅇ", member, board);
+
+    @Nested
+    @DisplayName("성공")
+    class Success {
+
+        @Test
+        @DisplayName("등록")
+        void commentCreate() {
+            // given
+            given(jwtProvider.mapTokenToId(any())).willReturn(1L);
+            given(memberRepository.findById(any())).willReturn(of(member));
+            given(boardRepository.findById(any())).willReturn(of(board));
+            given(commentRepository.save(any())).willReturn(comment);
+
+            // when
+            CommentResponseDto commentCreate = commentService.commentCreate(2L, "gfdsgs", "ㅎㅇ");
+
+            // then
+            assertThat(commentCreate.getContent()).isEqualTo("ㅎㅇ");
+        }
+
+        @Nested
+        @DisplayName("조회")
+        class Search {
+
+            @Test
+            @DisplayName("게시물에 있는 댓글 모두 조회")
+            void findComments() {
+                // given
+                List<Comment> commentList = List.of(comment);
+
+                given(boardRepository.findById(any())).willReturn(of(board));
+                given(commentQueryRepository.findCommentsByBoardId(any())).willReturn(commentList);
+
+                // when
+                List<CommentResponseDto> comments = commentService.findCommentsBoardById(any());
+
+                // then
+                assertThat(commentList.get(0).getContent()).isEqualTo(comments.get(0).getContent());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("실패")
+    class Failed {
+
+        @Nested
+        @DisplayName("등록")
+        class Create {
+
+            @Test
+            @DisplayName("등록할 때 회원을 찾지 못한 경우 예외")
+            void commentCreateNotFoundMember() {
+                // given
+                given(memberRepository.findById(any())).willThrow(new NotFoundMemberException(NOT_FOUND_MEMBER.getMessage()));
+
+                // when
+
+                // then
+                assertThatThrownBy(() -> commentService.commentCreate(board.getId(), "gdfgsfdg", "ㅎㅇ"))
+                        .isInstanceOf(NotFoundMemberException.class)
+                        .hasMessageContaining(NOT_FOUND_MEMBER.getMessage());
+            }
+
+            @Test
+            @DisplayName("등록할 때 게시물을 찾지 못한 경우 예외")
+            void commentCreateNotFoundBoard() {
+                // given
+                given(memberRepository.findById(any())).willReturn(of(member));
+                given(boardRepository.findById(any())).willThrow(new NotFoundBoardException(NOT_FOUND_BOARD.getMessage()));
+
+                // when
+
+                // then
+                assertThatThrownBy(() -> commentService.commentCreate(null, "gfdgdfgg","ㅎㅇ"))
+                        .isInstanceOf(NotFoundBoardException.class)
+                        .hasMessageContaining(NOT_FOUND_BOARD.getMessage());
+
+            }
+
+        }
+
+        @Nested
+        @DisplayName("조회")
+        class Search {
+
+            @Test
+            @DisplayName("조회할 때 게시물 id 값이 다른 경우")
+            void findCommentWrongBoardId() {
+                // given
+
+                // when
+
+                // then
+                assertThatThrownBy(() -> commentService.findCommentsBoardById(100L))
+                        .isInstanceOf(NotFoundBoardException.class)
+                        .hasMessageContaining(NOT_FOUND_BOARD.getMessage());
+            }
+        }
+    }
+}

--- a/src/test/java/com/example/yun/service/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/example/yun/service/impl/MemberServiceImplTest.java
@@ -1,0 +1,24 @@
+package com.example.yun.service.impl;
+
+import com.example.yun.repository.member.MemberRepository;
+import com.example.yun.repository.querydsl.MemberQueryRepository;
+import com.example.yun.service.MemberService;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceImplTest {
+
+    @InjectMocks
+    private MemberService memberService;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private MemberQueryRepository memberQueryRepository;
+
+
+}

--- a/src/test/java/com/example/yun/service/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/example/yun/service/impl/MemberServiceImplTest.java
@@ -1,24 +1,72 @@
 package com.example.yun.service.impl;
 
+import com.example.yun.domain.member.Member;
 import com.example.yun.repository.member.MemberRepository;
 import com.example.yun.repository.querydsl.MemberQueryRepository;
-import com.example.yun.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 
 @ExtendWith(MockitoExtension.class)
 class MemberServiceImplTest {
 
     @InjectMocks
-    private MemberService memberService;
+    private MemberServiceImpl memberService;
     @Mock
     private MemberRepository memberRepository;
     @Mock
     private MemberQueryRepository memberQueryRepository;
 
+    @Test
+    @DisplayName("회원 가입")
+    void memberCreateTest() {
+        // given
+        String email = "qwer1234@naver.com";
+        String pwd = "qwer1234@A";
 
+        Member member = Member.create(email, pwd);
+
+        given(memberRepository.save(any())).willReturn(member);
+
+        // when
+        Member memberCreate = memberService.memberCreate(email, pwd);
+
+        // then
+        assertThat(memberCreate).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("중복된 회원 가입")
+    void duplicatedMemberCreate() {
+        // given
+        String email = "qwer1234@naver.com";
+        String pwd = "qwer1234@A";
+
+        given(memberQueryRepository.duplicatedEmailCheck(email)).willReturn(true);
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> memberService.memberCreate(email, pwd))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    @DisplayName("로그인 테스트")
+    void loginTest() {
+        // given
+
+        // when
+
+        // then
+
+    }
 }


### PR DESCRIPTION
## level 7 PR

모그님 안녕하세요!! @mog-hi 

### 질문할 점
- spring interceptor에서 uri가 겹칠 경우 어떤식으로 패턴을 짜야할지 궁금합니다. 저는 인터셉터에서 jwt 유효성 검사를 거친 뒤 컨트롤러에서 로직을 수행하도록 설정 했는데 회원 가입은 /api/member uri를 가지고 있고 회원 찾기도 동일한 uri를 가지고 있습니다. 하지만 인터셉터에서 두 uri패턴이 같다 보니 둘 다 필터링이 되고 궁극적인 건 회원 가입은 jwt가 필요없고 회원 찾기는 jwt가 필요합니다. 제가 해결한 방법은 회원 가입 uri를 /api/member/create로 분리하여서 인터셉터 필터링이 안되도록 막았는데 이를 좀 더 효과적으로 수행할 수 있는 방법이 있을까요?
- 다음은 회원 도메인에 정규식을 validated 로직이 있고 DTO에도 존재합니다.  근데 둘 다 validated 하는 것이 효과적인가요? 아니면 하나의 계층만 validated 하는것이 옳을까요?